### PR TITLE
systemc-components/registers: introduce the register bank for handlin…

### DIFF
--- a/systemc-components/common/include/reg_model_maker/reg_model_maker.h
+++ b/systemc-components/common/include/reg_model_maker/reg_model_maker.h
@@ -401,7 +401,7 @@ public:
     }
 
     template <class TYPE>
-    void bind_reg(gs::gs_register<TYPE>& reg)
+    void bind_reg(gs::gs_register<TYPE>& reg, uint32_t priority = 0)
     {
         std::string path = reg.get_path();
         std::string self_full_name = std::string(sc_core::sc_module::name());
@@ -425,6 +425,19 @@ public:
         std::string reg_address_str = reg_target_socket_name + ".address";
         uint64_t new_reg_offset = reg.get_offset() + mod_address + (m_jza.is_platform_model() ? parent_address : 0);
         cci_set<uint64_t>(reg_address_str, new_reg_offset);
+        if constexpr (gs::is_gs_bank<TYPE>::value) {
+            auto encode_dims = [](const std::vector<uint64_t>& values) {
+                std::string result;
+                for (size_t i = 0; i < values.size(); ++i) {
+                    if (i != 0) result += ',';
+                    result += std::to_string(values[i]);
+                }
+                return result;
+            };
+            cci_set<std::string>(reg_target_socket_name + ".dim_strides", encode_dims(reg.get_dim_strides()));
+            cci_set<std::string>(reg_target_socket_name + ".dim_counts", encode_dims(reg.get_dim_counts()));
+        }
+        if (priority != 0) cci_set<uint32_t>(reg_target_socket_name + ".priority", priority);
         m_sh_comp->m_reg_router->initiator_socket.bind(reg);
         m_sh_comp->m_reg_router->rename_last(reg_target_socket_name);
         m_bound_regs_num++;

--- a/systemc-components/common/include/registers.h
+++ b/systemc-components/common/include/registers.h
@@ -22,6 +22,11 @@
 #include <algorithm>
 #include <limits>
 #include <bitset>
+#include <initializer_list>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
 
 namespace gs {
 
@@ -30,6 +35,42 @@ static T gs_full_mask()
 {
     return static_cast<T>(std::bitset<std::numeric_limits<T>::digits>(0).flip().to_ullong());
 }
+
+template <typename T>
+static T gs_mask_for_field(uint32_t start, uint32_t length)
+{
+    constexpr uint32_t width = std::numeric_limits<T>::digits;
+    if (length == 0 || start >= width || length > width - start) {
+        sc_assert(false);
+        return 0;
+    }
+    if (length == width) return gs_full_mask<T>();
+    return static_cast<T>(gs_full_mask<T>() >> (width - length));
+}
+
+/** Bank descriptor: template parameter for the gs_register bank specialisation. */
+template <class ELEM = uint32_t>
+struct gs_bank_of {
+    using elem_type = ELEM;
+    static_assert(std::is_unsigned<ELEM>::value, "Bank element type must be unsigned");
+};
+
+template <class>
+struct is_gs_bank : std::false_type {
+};
+template <class E>
+struct is_gs_bank<gs_bank_of<E>> : std::true_type {
+};
+
+/** Result of decoding a transaction against a bank layout; `bool` == on-element. */
+struct gs_bank_access {
+    uint64_t index;                // flat row-major index
+    uint64_t byte_offset;          // addr - base
+    std::vector<uint64_t> indices; // per-dim, outer to inner
+    bool aligned;
+    bool in_range;
+    explicit operator bool() const { return aligned && in_range; }
+};
 
 /**
  * @brief  Provide a class to provide b_transport callback
@@ -191,28 +232,33 @@ class proxy_data_array
     {
         tlm::tlm_generic_payload m_txn;
         tlm::tlm_dmi m_dmi_data;
+        const uint64_t span = p_size.get_value();
         m_txn.set_byte_enable_length(0);
         m_txn.set_dmi_allowed(false);
         m_txn.set_command(tlm::TLM_IGNORE_COMMAND);
         m_txn.set_data_ptr(nullptr);
         m_txn.set_address(p_offset);
-        m_txn.set_data_length(sizeof(TYPE) * p_number);
-        m_txn.set_streaming_width(sizeof(TYPE) * p_number);
+        m_txn.set_data_length(span);
+        m_txn.set_streaming_width(span);
         m_txn.set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
         if (initiator_socket->get_direct_mem_ptr(m_txn, m_dmi_data)) {
             uint64_t start = m_dmi_data.get_start_address();
             unsigned char* ptr = m_dmi_data.get_dmi_ptr();
             ptr += (p_offset - start);
-            sc_assert(m_dmi_data.get_end_address() >= start + p_offset + (p_number * sizeof(TYPE)));
+            sc_assert(m_dmi_data.get_end_address() >= start + p_offset + span);
             m_dmi = reinterpret_cast<TYPE*>(ptr);
         }
     }
+
+    uint8_t* dmi_bytes_at(uint64_t idx) { return reinterpret_cast<uint8_t*>(m_dmi) + p_stride.get_value() * idx; }
 
 public:
     std::string m_path_name;
     cci::cci_param<uint64_t> p_number;
     cci::cci_param<uint64_t> p_offset;
     cci::cci_param<uint64_t> p_size;
+    cci::cci_param<uint64_t> p_stride;
+    cci::cci_param<uint64_t> p_elem_size;
     cci::cci_param<TYPE> p_mask;
     cci::cci_param<bool> p_relative_addresses;
 
@@ -221,69 +267,117 @@ public:
     void get(TYPE* dst, uint64_t idx = 0, uint64_t length = 1)
     {
         sc_assert(idx + length <= p_number);
+        const uint64_t stride = p_stride.get_value();
         if (m_dmi) {
-            memcpy(dst, &m_dmi[idx], sizeof(TYPE) * length);
+            for (uint64_t i = 0; i < length; i++) memcpy(&dst[i], dmi_bytes_at(idx + i), sizeof(TYPE));
             SCP_TRACE(())("Got value (DMI) : [{:#x}]", fmt::join(std::vector<TYPE>(&dst[0], &dst[length]), ","));
-        } else {
+        } else if (length == 1 || stride == sizeof(TYPE)) {
             tlm::tlm_generic_payload m_txn;
             sc_core::sc_time dummy;
             m_txn.set_byte_enable_length(0);
             m_txn.set_dmi_allowed(false);
             m_txn.set_command(tlm::TLM_READ_COMMAND);
             m_txn.set_data_ptr(reinterpret_cast<unsigned char*>(dst));
-            m_txn.set_address(p_offset + (sizeof(TYPE) * idx));
+            m_txn.set_address(p_offset + stride * idx);
             m_txn.set_data_length(sizeof(TYPE) * length);
             m_txn.set_streaming_width(sizeof(TYPE) * length);
             m_txn.set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
             initiator_socket->b_transport(m_txn, dummy);
             sc_assert(m_txn.get_response_status() == tlm::TLM_OK_RESPONSE);
             SCP_TRACE(())("Got value (transport) : [{:#x}]", fmt::join(std::vector<TYPE>(&dst[0], &dst[length]), ","));
-            if (m_txn.is_dmi_allowed()) {
-                check_dmi();
+            if (m_txn.is_dmi_allowed()) check_dmi();
+        } else {
+            // gapped bank: one transaction per element
+            for (uint64_t i = 0; i < length; i++) {
+                tlm::tlm_generic_payload m_txn;
+                sc_core::sc_time dummy;
+                m_txn.set_byte_enable_length(0);
+                m_txn.set_dmi_allowed(false);
+                m_txn.set_command(tlm::TLM_READ_COMMAND);
+                m_txn.set_data_ptr(reinterpret_cast<unsigned char*>(&dst[i]));
+                m_txn.set_address(p_offset + stride * (idx + i));
+                m_txn.set_data_length(sizeof(TYPE));
+                m_txn.set_streaming_width(sizeof(TYPE));
+                m_txn.set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
+                initiator_socket->b_transport(m_txn, dummy);
+                sc_assert(m_txn.get_response_status() == tlm::TLM_OK_RESPONSE);
+                if (m_txn.is_dmi_allowed()) check_dmi();
             }
+            SCP_TRACE(())
+            ("Got value (transport strided) : [{:#x}]", fmt::join(std::vector<TYPE>(&dst[0], &dst[length]), ","));
         }
     }
 
     void set(TYPE* src, uint64_t idx = 0, uint64_t length = 1, bool use_mask = true)
     {
         sc_assert(idx + length <= p_number);
+        const uint64_t stride = p_stride.get_value();
+        const bool full_mask = (p_mask.get_value() == gs_full_mask<TYPE>());
         if (m_dmi) {
             SCP_TRACE(())("Set value (DMI) : [{:#x}]", fmt::join(std::vector<TYPE>(&src[0], &src[length]), ","));
-            TYPE curr_val = m_dmi[idx];
-            if (!use_mask || (p_mask.get_value() == gs_full_mask<TYPE>())) {
-                memcpy(&m_dmi[idx], src, sizeof(TYPE) * length);
+            if (!use_mask || full_mask) {
+                for (uint64_t i = 0; i < length; i++) memcpy(dmi_bytes_at(idx + i), &src[i], sizeof(TYPE));
             } else {
-                write_with_mask(src, reinterpret_cast<TYPE*>(&m_dmi[idx]), length);
+                for (uint64_t i = 0; i < length; i++) {
+                    TYPE cur;
+                    memcpy(&cur, dmi_bytes_at(idx + i), sizeof(TYPE));
+                    write_with_mask(&src[i], &cur, 1);
+                    memcpy(dmi_bytes_at(idx + i), &cur, sizeof(TYPE));
+                }
             }
-        } else {
+        } else if ((length == 1 || stride == sizeof(TYPE)) && (full_mask || !use_mask)) {
             tlm::tlm_generic_payload m_txn;
             sc_core::sc_time dummy;
-            std::vector<unsigned char> curr_data;
-            if ((p_mask.get_value() == gs_full_mask<TYPE>()) || !use_mask) {
-                m_txn.set_data_ptr(reinterpret_cast<unsigned char*>(src));
-            } else {
-                curr_data.resize(sizeof(TYPE) * length);
-                get(reinterpret_cast<TYPE*>(curr_data.data()), idx, length);
-                write_with_mask(src, reinterpret_cast<TYPE*>(curr_data.data()), length);
-                m_txn.set_data_ptr(reinterpret_cast<unsigned char*>(curr_data.data()));
-            }
+            m_txn.set_data_ptr(reinterpret_cast<unsigned char*>(src));
             m_txn.set_byte_enable_length(0);
             m_txn.set_dmi_allowed(false);
             m_txn.set_command(tlm::TLM_WRITE_COMMAND);
-            m_txn.set_address(p_offset + (sizeof(TYPE) * idx));
+            m_txn.set_address(p_offset + stride * idx);
             m_txn.set_data_length(sizeof(TYPE) * length);
             m_txn.set_streaming_width(sizeof(TYPE) * length);
             m_txn.set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
             SCP_TRACE(())("Set value (transport) : [{:#x}]", fmt::join(std::vector<TYPE>(&src[0], &src[length]), ","));
             initiator_socket->b_transport(m_txn, dummy);
             sc_assert(m_txn.get_response_status() == tlm::TLM_OK_RESPONSE);
-            if (m_txn.is_dmi_allowed()) {
-                check_dmi();
+            if (m_txn.is_dmi_allowed()) check_dmi();
+        } else {
+            for (uint64_t i = 0; i < length; i++) {
+                tlm::tlm_generic_payload m_txn;
+                sc_core::sc_time dummy;
+                std::vector<unsigned char> curr_data;
+                unsigned char* data_ptr;
+                if (!use_mask || full_mask) {
+                    data_ptr = reinterpret_cast<unsigned char*>(&src[i]);
+                } else {
+                    curr_data.resize(sizeof(TYPE));
+                    get(reinterpret_cast<TYPE*>(curr_data.data()), idx + i, 1);
+                    TYPE tmp = src[i];
+                    write_with_mask(&tmp, reinterpret_cast<TYPE*>(curr_data.data()), 1);
+                    data_ptr = curr_data.data();
+                }
+                m_txn.set_data_ptr(data_ptr);
+                m_txn.set_byte_enable_length(0);
+                m_txn.set_dmi_allowed(false);
+                m_txn.set_command(tlm::TLM_WRITE_COMMAND);
+                m_txn.set_address(p_offset + stride * (idx + i));
+                m_txn.set_data_length(sizeof(TYPE));
+                m_txn.set_streaming_width(sizeof(TYPE));
+                m_txn.set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
+                initiator_socket->b_transport(m_txn, dummy);
+                sc_assert(m_txn.get_response_status() == tlm::TLM_OK_RESPONSE);
+                if (m_txn.is_dmi_allowed()) check_dmi();
             }
+            SCP_TRACE(())
+            ("Set value (transport strided) : [{:#x}]", fmt::join(std::vector<TYPE>(&src[0], &src[length]), ","));
         }
     }
 
     void write_with_mask(TYPE* src, TYPE* dst, uint64_t length)
+    {
+        write_with_mask(src, dst, length, p_mask.get_value());
+    }
+
+    void write_with_mask(TYPE* src, TYPE* dst, uint64_t length, TYPE mask)
     {
         if (!src) {
             SCP_FATAL(())("write_with_mask(): src pointer is NULL");
@@ -291,7 +385,7 @@ public:
         if (!dst) {
             SCP_FATAL(())("write_with_mask(): dst pointer is NULL");
         }
-        std::vector<TYPE> mask_to_apply(length, p_mask.get_value());
+        std::vector<TYPE> mask_to_apply(length, mask);
         std::vector<TYPE> new_and_mask(length, 0);     // result of *src & mask
         std::vector<TYPE> old_and_not_mask(length, 0); // result of *dmi & ~mask
         std::transform(src, src + length, mask_to_apply.cbegin(), new_and_mask.begin(),
@@ -317,22 +411,98 @@ public:
                           << " has readonly bits, please use set(TYPE* src, uint64_t idx, uint64_t length) and "
                              "get(TYPE* dst, uint64_t idx, uint64_t length) instead";
         }
-        return m_dmi[idx];
+        return *reinterpret_cast<TYPE*>(dmi_bytes_at(static_cast<uint64_t>(idx)));
     }
+
+    /** Single-element read at a raw byte offset relative to p_offset. */
+    void get_bytes(TYPE* dst, uint64_t byte_offset)
+    {
+        if (m_dmi) {
+            memcpy(dst, reinterpret_cast<uint8_t*>(m_dmi) + byte_offset, sizeof(TYPE));
+        } else {
+            tlm::tlm_generic_payload m_txn;
+            sc_core::sc_time dummy;
+            m_txn.set_byte_enable_length(0);
+            m_txn.set_dmi_allowed(false);
+            m_txn.set_command(tlm::TLM_READ_COMMAND);
+            m_txn.set_data_ptr(reinterpret_cast<unsigned char*>(dst));
+            m_txn.set_address(p_offset + byte_offset);
+            m_txn.set_data_length(sizeof(TYPE));
+            m_txn.set_streaming_width(sizeof(TYPE));
+            m_txn.set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
+            initiator_socket->b_transport(m_txn, dummy);
+            sc_assert(m_txn.get_response_status() == tlm::TLM_OK_RESPONSE);
+            if (m_txn.is_dmi_allowed()) check_dmi();
+        }
+    }
+
+    /** Single-element write at a raw byte offset; RMW-masked when use_mask && !full_mask. */
+    void set_bytes(TYPE* src, uint64_t byte_offset, bool use_mask = true)
+    {
+        const TYPE mask = mask_for_byte_offset(byte_offset);
+        const bool full_mask = (mask == gs_full_mask<TYPE>());
+        if (m_dmi) {
+            if (!use_mask || full_mask) {
+                memcpy(reinterpret_cast<uint8_t*>(m_dmi) + byte_offset, src, sizeof(TYPE));
+            } else {
+                TYPE cur;
+                memcpy(&cur, reinterpret_cast<uint8_t*>(m_dmi) + byte_offset, sizeof(TYPE));
+                write_with_mask(src, &cur, 1, mask);
+                memcpy(reinterpret_cast<uint8_t*>(m_dmi) + byte_offset, &cur, sizeof(TYPE));
+            }
+        } else {
+            tlm::tlm_generic_payload m_txn;
+            sc_core::sc_time dummy;
+            std::vector<unsigned char> curr_data;
+            unsigned char* data_ptr;
+            if (!use_mask || full_mask) {
+                data_ptr = reinterpret_cast<unsigned char*>(src);
+            } else {
+                curr_data.resize(sizeof(TYPE));
+                get_bytes(reinterpret_cast<TYPE*>(curr_data.data()), byte_offset);
+                TYPE tmp = *src;
+                write_with_mask(&tmp, reinterpret_cast<TYPE*>(curr_data.data()), 1, mask);
+                data_ptr = curr_data.data();
+            }
+            m_txn.set_data_ptr(data_ptr);
+            m_txn.set_byte_enable_length(0);
+            m_txn.set_dmi_allowed(false);
+            m_txn.set_command(tlm::TLM_WRITE_COMMAND);
+            m_txn.set_address(p_offset + byte_offset);
+            m_txn.set_data_length(sizeof(TYPE));
+            m_txn.set_streaming_width(sizeof(TYPE));
+            m_txn.set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
+            initiator_socket->b_transport(m_txn, dummy);
+            sc_assert(m_txn.get_response_status() == tlm::TLM_OK_RESPONSE);
+            if (m_txn.is_dmi_allowed()) check_dmi();
+        }
+    }
+
     void invalidate_direct_mem_ptr(sc_dt::uint64 start, sc_dt::uint64 end) { m_dmi = nullptr; }
 
+protected:
+    virtual bool has_element_masks() const { return false; }
+    virtual TYPE mask_for_element(uint64_t index) const { return p_mask.get_value(); }
+    virtual TYPE mask_for_byte_offset(uint64_t byte_offset) const { return p_mask.get_value(); }
+
+public:
     proxy_data_array(scp::scp_logger_cache& logger, std::string name, std::string path_name, uint64_t _offset = 0,
-                     uint64_t number = 1, TYPE mask = gs_full_mask<TYPE>())
+                     uint64_t number = 1, TYPE mask = gs_full_mask<TYPE>(), uint64_t stride = sizeof(TYPE),
+                     uint64_t total_span_override = 0)
         : SCP_LOGGER_NAME()(logger)
         , m_path_name(path_name)
         , p_number(path_name + ".number", number, "number of elements in this register")
         , initiator_socket((name + "_initiator_socket").c_str())
         , p_offset(path_name + ".target_socket.address", _offset, "Offset of this register")
-        , p_size(path_name + ".target_socket.size", sizeof(TYPE) * number, "size of this register")
+        , p_size(path_name + ".target_socket.size",
+                 (total_span_override != 0 ? total_span_override
+                                           : (number == 0 ? 0 : stride * (number - 1) + sizeof(TYPE))),
+                 "size of this register")
+        , p_stride(path_name + ".target_socket.stride", stride, "stride in bytes between elements")
+        , p_elem_size(path_name + ".target_socket.elem_size", sizeof(TYPE), "size in bytes of one element")
         , p_mask(path_name + ".target_socket.mask", mask, " R/W mask, 0 means read only, and 1 means write/read")
         , p_relative_addresses(path_name + ".target_socket.relative_addresses", true,
                                "allow relative_addresses for this register")
-
     {
         initiator_socket.register_invalidate_direct_mem_ptr(this,
                                                             &gs::proxy_data_array<TYPE>::invalidate_direct_mem_ptr);
@@ -406,21 +576,21 @@ public:
         SCP_TRACE((), n)("constructor : {} attching in {}", _name, path);
 
         register_transport_dbg_func([&](tlm::tlm_generic_payload& txn) {
-            if (txn.get_data_length() < sizeof(TYPE)) return (unsigned int)0;
+            if (txn.get_data_length() < sizeof(TYPE)) return static_cast<unsigned int>(0);
             unsigned char* data = txn.get_data_ptr();
             if (txn.get_command() == tlm::TLM_READ_COMMAND) {
                 TYPE tmp = proxy_data<TYPE>::get();
                 memset(data, 0, txn.get_data_length());
                 memcpy(data, &tmp, sizeof(TYPE));
-                return (unsigned int)sizeof(TYPE);
+                return static_cast<unsigned int>(sizeof(TYPE));
             }
             if (txn.get_command() == tlm::TLM_WRITE_COMMAND) {
                 TYPE tmp;
                 memcpy(&tmp, data, sizeof(TYPE));
                 proxy_data<TYPE>::set(tmp);
-                return (unsigned int)sizeof(TYPE);
+                return static_cast<unsigned int>(sizeof(TYPE));
             }
-            return (unsigned int)0;
+            return static_cast<unsigned int>(0);
         });
     }
     void operator=(TYPE value) { proxy_data<TYPE>::set(value); }
@@ -469,11 +639,12 @@ public:
         if ((txn_data_len == 0) || (txn_data_len % sizeof(TYPE)))
             SCP_FATAL(()) << "capture_txn_pre(): txn data length should be n * sizeof(TYPE) where n >= 1";
         uint64_t txn_addr = txn.get_address();
+        const uint64_t stride = proxy_data<TYPE>::p_stride.get_value();
         uint64_t idx = 0;
         if (proxy_data<TYPE>::p_relative_addresses.get_value()) {
-            idx = txn_addr / sizeof(TYPE);
+            idx = txn_addr / stride;
         } else {
-            idx = (txn_addr - proxy_data<TYPE>::p_offset.get_value()) / sizeof(TYPE);
+            idx = (txn_addr - proxy_data<TYPE>::p_offset.get_value()) / stride;
         }
         captured_txn_data.clear();
         captured_txn_data.resize(txn_data_len);
@@ -489,11 +660,12 @@ public:
         if ((txn_data_len == 0) || (txn_data_len % sizeof(TYPE)))
             SCP_FATAL(()) << "handle_mask_post(): txn data length should be n * sizeof(TYPE) where n >= 1";
         uint64_t txn_addr = txn.get_address();
+        const uint64_t stride = proxy_data<TYPE>::p_stride.get_value();
         uint64_t idx = 0;
         if (proxy_data<TYPE>::p_relative_addresses.get_value()) {
-            idx = txn_addr / sizeof(TYPE);
+            idx = txn_addr / stride;
         } else {
-            idx = (txn_addr - proxy_data<TYPE>::p_offset.get_value()) / sizeof(TYPE);
+            idx = (txn_addr - proxy_data<TYPE>::p_offset.get_value()) / stride;
         }
         unsigned char* txn_data_ptr = txn.get_data_ptr();
         proxy_data<TYPE>::write_with_mask(reinterpret_cast<TYPE*>(txn_data_ptr),
@@ -521,11 +693,17 @@ public:
 
     void operator=(TYPE value)
     {
-        sc_assert(value < (1ull << length));
-        m_reg &= ~(((1ull << length) - 1) << start);
-        m_reg |= value << start;
+        TYPE field_mask = gs_mask_for_field<TYPE>(start, length);
+        sc_assert((value & ~field_mask) == 0);
+        TYPE mask = static_cast<TYPE>(field_mask << start);
+        m_reg &= static_cast<TYPE>(~mask);
+        m_reg |= static_cast<TYPE>((value & field_mask) << start);
     }
-    operator TYPE() { return (m_reg >> start) & ((1ull << length) - 1); }
+    operator TYPE()
+    {
+        TYPE field_mask = gs_mask_for_field<TYPE>(start, length);
+        return static_cast<TYPE>((m_reg >> start) & field_mask);
+    }
 };
 
 /**
@@ -537,25 +715,61 @@ template <class TYPE>
 class gs_field
 {
     SCP_LOGGER();
-    gs_register<TYPE>& m_reg;
+    std::string m_name;
     uint32_t m_bit_start;
     uint32_t m_bit_length;
-    gs_bitfield<TYPE> m_bitfield;
+    std::optional<gs_bitfield<TYPE>> m_bitfield;
 
-public:
-    gs_field(gs_register<TYPE>& reg, std::string name, uint32_t bit_start = 0, uint32_t bit_length = sizeof(TYPE) * 8)
-        : m_reg(reg), m_bit_start(bit_start), m_bit_length(bit_length), m_bitfield(reg, m_bit_start, m_bit_length)
+    void require_bound() const
     {
-        SCP_TRACE(())("gs_field constructor");
-        if (m_bit_length == 0) SCP_FATAL(())("Can't find bit length for {}", name);
+        if (!m_bitfield) {
+            SCP_FATAL(())("Field {} is metadata-only and is not attached to a scalar register", m_name);
+        }
     }
 
-    void operator=(TYPE value) { m_bitfield = value; }
-    void operator=(gs_field<TYPE>& value) { m_bitfield = (TYPE)value; }
+public:
+    /**
+     * Construct a field for either a scalar register or a register bank.
+     * For a bank, the register argument keeps declaration and initialization
+     * uniform; the bank element supplies the actual storage on access.
+     */
+    template <class REG>
+    gs_field(REG& reg, std::string name, uint32_t bit_start = 0, uint32_t bit_length = sizeof(TYPE) * 8)
+        : m_name(std::move(name)), m_bit_start(bit_start), m_bit_length(bit_length), m_bitfield(std::nullopt)
+    {
+        using REG_TYPE = std::remove_reference_t<REG>;
+        static_assert(std::is_same<REG_TYPE, gs_register<TYPE>>::value ||
+                          std::is_same<REG_TYPE, gs_register<gs_bank_of<TYPE>>>::value,
+                      "gs_field must be constructed with gs_register<T> or gs_register<gs_bank_of<T>>");
+        SCP_TRACE(())("gs_field constructor");
+        if (m_bit_length == 0) SCP_FATAL(())("Can't find bit length for {}", m_name);
+        if constexpr (std::is_same<REG_TYPE, gs_register<TYPE>>::value) {
+            m_bitfield.emplace(reg, m_bit_start, m_bit_length);
+        }
+    }
 
-    operator TYPE() { return m_bitfield; }
+    void operator=(TYPE value)
+    {
+        require_bound();
+        *m_bitfield = value;
+    }
+    void operator=(gs_field<TYPE>& value)
+    {
+        require_bound();
+        *m_bitfield = static_cast<TYPE>(value);
+    }
 
-    operator gs::gs_bitfield<TYPE>&() { return m_bitfield; }
+    operator TYPE()
+    {
+        require_bound();
+        return static_cast<TYPE>(*m_bitfield);
+    }
+
+    operator gs::gs_bitfield<TYPE>&()
+    {
+        require_bound();
+        return *m_bitfield;
+    }
 
     uint32_t bit_start() const { return m_bit_start; }
     uint32_t bit_length() const { return m_bit_length; }
@@ -573,11 +787,16 @@ class gs_register_element
 
     public:
         field_proxy(TYPE& ref, uint32_t start, uint32_t length): m_ref(ref), m_start(start), m_length(length) {}
-        operator TYPE() const { return (m_ref >> m_start) & ((1ull << m_length) - 1); }
+        operator TYPE() const
+        {
+            TYPE field_mask = gs_mask_for_field<TYPE>(m_start, m_length);
+            return static_cast<TYPE>((m_ref >> m_start) & field_mask);
+        }
         field_proxy& operator=(TYPE value)
         {
-            TYPE mask = ((1ull << m_length) - 1) << m_start;
-            m_ref = (m_ref & ~mask) | ((value & ((1ull << m_length) - 1)) << m_start);
+            TYPE field_mask = gs_mask_for_field<TYPE>(m_start, m_length);
+            TYPE mask = static_cast<TYPE>(field_mask << m_start);
+            m_ref = static_cast<TYPE>((m_ref & ~mask) | ((value & field_mask) << m_start));
             return *this;
         }
     };
@@ -600,6 +819,580 @@ gs_register_element<TYPE> gs_register<TYPE>::operator[](int idx)
 {
     return gs_register_element<TYPE>(proxy_data_array<TYPE>::operator[](idx));
 }
+
+/**
+ * Cursor into a gs_register<gs_bank_of<E>>. Either a partially-resolved slice
+ * (narrows via operator[](size_t)) or a fully-resolved element (assign / read
+ * / RMW / [gs_field]). is_full() reports which.
+ */
+template <class ELEM>
+class gs_register_bank_element
+{
+    SCP_LOGGER();
+    proxy_data_array<ELEM>& m_bank;
+    const std::vector<uint64_t>* m_strides;
+    const std::vector<uint64_t>* m_counts;
+    uint64_t m_byte_off;
+    size_t m_next_dim;
+
+    class bit_proxy
+    {
+        gs_register_bank_element& m_elem;
+        uint32_t m_start, m_length;
+
+    public:
+        bit_proxy(gs_register_bank_element& e, uint32_t s, uint32_t l): m_elem(e), m_start(s), m_length(l) {}
+        operator ELEM() const
+        {
+            ELEM field_mask = gs_mask_for_field<ELEM>(m_start, m_length);
+            return static_cast<ELEM>((static_cast<ELEM>(m_elem) >> m_start) & field_mask);
+        }
+        bit_proxy& operator=(ELEM value)
+        {
+            ELEM cur = m_elem;
+            ELEM field_mask = gs_mask_for_field<ELEM>(m_start, m_length);
+            ELEM mask = static_cast<ELEM>(field_mask << m_start);
+            m_elem = static_cast<ELEM>((cur & ~mask) | ((value & field_mask) << m_start));
+            return *this;
+        }
+    };
+
+    void require_full(const char* op) const
+    {
+        if (!is_full()) {
+            SCP_FATAL(())
+            ("operation '{}' requires a fully-resolved bank element; {} of {} dims specified", op, m_next_dim,
+             m_strides->size());
+        }
+    }
+
+public:
+    gs_register_bank_element(proxy_data_array<ELEM>& bank, const std::vector<uint64_t>& strides,
+                             const std::vector<uint64_t>& counts, uint64_t byte_off, size_t next_dim)
+        : m_bank(bank), m_strides(&strides), m_counts(&counts), m_byte_off(byte_off), m_next_dim(next_dim)
+    {
+    }
+
+    bool is_full() const { return m_next_dim >= m_strides->size(); }
+    uint64_t byte_offset() const { return m_byte_off; }
+    size_t dims_resolved() const { return m_next_dim; }
+    size_t dims_total() const { return m_strides->size(); }
+
+    gs_register_bank_element operator[](size_t idx)
+    {
+        if (is_full()) {
+            SCP_FATAL(())("operator[](size_t) on fully-resolved bank element ({} dims already consumed)", m_next_dim);
+        }
+        if (idx >= (*m_counts)[m_next_dim]) {
+            SCP_FATAL(())("bank index {} at dim {} exceeds count {}", idx, m_next_dim, (*m_counts)[m_next_dim]);
+        }
+        return gs_register_bank_element(m_bank, *m_strides, *m_counts, m_byte_off + idx * (*m_strides)[m_next_dim],
+                                        m_next_dim + 1);
+    }
+
+    operator ELEM() const
+    {
+        require_full("read");
+        ELEM v;
+        const_cast<proxy_data_array<ELEM>&>(m_bank).get_bytes(&v, m_byte_off);
+        return v;
+    }
+
+    gs_register_bank_element& operator=(ELEM value)
+    {
+        require_full("assign");
+        m_bank.set_bytes(&value, m_byte_off);
+        return *this;
+    }
+    gs_register_bank_element& operator=(const gs_register_bank_element& other)
+    {
+        require_full("assign");
+        ELEM v = static_cast<ELEM>(other);
+        m_bank.set_bytes(&v, m_byte_off);
+        return *this;
+    }
+
+#define GS_BANK_ELEM_RMW(op, name)                     \
+    gs_register_bank_element& operator op##=(ELEM rhs) \
+    {                                                  \
+        require_full(name);                            \
+        ELEM v = static_cast<ELEM>(*this) op rhs;      \
+        m_bank.set_bytes(&v, m_byte_off);              \
+        return *this;                                  \
+    }
+    GS_BANK_ELEM_RMW(+, "+=")
+    GS_BANK_ELEM_RMW(-, "-=")
+    GS_BANK_ELEM_RMW(*, "*=")
+    GS_BANK_ELEM_RMW(&, "&=")
+    GS_BANK_ELEM_RMW(|, "|=")
+    GS_BANK_ELEM_RMW(^, "^=")
+    GS_BANK_ELEM_RMW(<<, "<<=")
+    GS_BANK_ELEM_RMW(>>, ">>=")
+#undef GS_BANK_ELEM_RMW
+
+    gs_register_bank_element& operator/=(ELEM rhs)
+    {
+        require_full("/=");
+        if (rhs == 0) SCP_FATAL(())("division by zero on bank element");
+        ELEM v = static_cast<ELEM>(*this) / rhs;
+        m_bank.set_bytes(&v, m_byte_off);
+        return *this;
+    }
+
+    /** Bit-field access on a fully-resolved element: bank[i][m][n][field] = v; */
+    bit_proxy operator[](gs_field<ELEM>& f)
+    {
+        require_full("[gs_field]");
+        return bit_proxy(*this, f.bit_start(), f.bit_length());
+    }
+};
+
+/**
+ * gs_register specialisation for a register bank. Covers a strided N-D layout
+ * as a single target socket; every element access routes through one
+ * gs_register instance.
+ *   addr(i0..iD-1) = base + sum_k(i_k * strides[k])
+ * Outer dim first; strides must be non-overlapping (checked at construction).
+ */
+template <class ELEM>
+class gs_register<gs_bank_of<ELEM>> : public port_fnct, public proxy_data_array<ELEM>
+{
+    SCP_LOGGER((), "register");
+
+    std::string m_regname;
+    std::string m_path;
+    std::vector<unsigned char> captured_txn_data;
+    std::unordered_map<uint64_t, ELEM> m_element_masks;
+
+    std::vector<uint64_t> m_dim_counts;
+    std::vector<uint64_t> m_dim_strides;
+    // m_row_major_div[k] = prod(counts[k+1..]); used to unravel flat indices.
+    std::vector<uint64_t> m_row_major_div;
+    uint64_t m_total_count = 0;
+    uint64_t m_total_span = 0;
+
+    static uint64_t compute_total_span(const std::vector<uint64_t>& counts, const std::vector<uint64_t>& strides)
+    {
+        if (counts.empty() || counts.size() != strides.size()) return 0;
+        uint64_t span = 0;
+        for (size_t k = 0; k < counts.size(); k++) {
+            if (counts[k] == 0) return 0;
+            span += (counts[k] - 1) * strides[k];
+        }
+        return span + sizeof(ELEM);
+    }
+
+    static uint64_t compute_total_count(const std::vector<uint64_t>& counts)
+    {
+        uint64_t c = 1;
+        for (auto v : counts) c *= v;
+        return c;
+    }
+
+    uint64_t flat_index_for_indices(const uint64_t* indices, size_t n) const
+    {
+        if (n != m_dim_counts.size())
+            SCP_FATAL(())("bank {} indexed with {} dims, expected {}", m_regname, n, m_dim_counts.size());
+        uint64_t flat = 0;
+        for (size_t k = 0; k < n; k++) {
+            if (indices[k] >= m_dim_counts[k])
+                SCP_FATAL(())("bank {} index {} at dim {} exceeds count {}", m_regname, indices[k], k, m_dim_counts[k]);
+            flat += indices[k] * m_row_major_div[k];
+        }
+        return flat;
+    }
+
+    bool try_flat_index_for_byte_offset(uint64_t byte_offset, uint64_t& flat) const
+    {
+        uint64_t remaining = byte_offset;
+        flat = 0;
+        for (size_t k = 0; k < m_dim_strides.size(); k++) {
+            uint64_t idx = remaining / m_dim_strides[k];
+            remaining %= m_dim_strides[k];
+            if (idx >= m_dim_counts[k]) return false;
+            flat += idx * m_row_major_div[k];
+        }
+        return remaining < sizeof(ELEM);
+    }
+
+    // Comma-separated decimal for CCI transport; reg_router parses via std::stoull.
+    static std::string encode_vec(const std::vector<uint64_t>& v)
+    {
+        std::string out;
+        for (size_t i = 0; i < v.size(); i++) {
+            if (i) out += ',';
+            out += std::to_string(v[i]);
+        }
+        return out;
+    }
+
+    void init_common(const std::string& _name, const std::string& path)
+    {
+        std::string n(name());
+        SCP_LOGGER_NAME().features[0] = parent(n) + "." + _name;
+        n = n.substr(0, n.length() - strlen("_target_socket"));
+
+        m_total_count = compute_total_count(m_dim_counts);
+        m_total_span = compute_total_span(m_dim_counts, m_dim_strides);
+
+        m_row_major_div.assign(m_dim_counts.size(), 1);
+        for (size_t k = m_dim_counts.size(); k-- > 1;) m_row_major_div[k - 1] = m_row_major_div[k] * m_dim_counts[k];
+
+        // Each outer stride must cover the span of all inner dims; otherwise the
+        // router's claim() cannot uniquely invert an address into per-dim indices.
+        for (size_t k = 0; k + 1 < m_dim_strides.size(); k++) {
+            uint64_t inner_span = 0;
+            for (size_t j = k + 1; j < m_dim_strides.size(); j++)
+                inner_span += (m_dim_counts[j] - 1) * m_dim_strides[j];
+            inner_span += sizeof(ELEM);
+            if (m_dim_strides[k] < inner_span) {
+                SCP_FATAL(())
+                ("bank {} dim {} stride 0x{:x} < inner span 0x{:x}: layout is ambiguous", _name, k, m_dim_strides[k],
+                 inner_span);
+            }
+        }
+        if (!m_dim_strides.empty() && m_dim_strides.back() < sizeof(ELEM)) {
+            SCP_FATAL(())
+            ("bank {} innermost stride 0x{:x} < sizeof(elem)={}", _name, m_dim_strides.back(), (uint64_t)sizeof(ELEM));
+        }
+
+        proxy_data_array<ELEM>::p_size = m_total_span;
+
+        SCP_TRACE((), n)
+        ("bank constructor : {} dims={} total_count={} span=0x{:x} in {}", _name, m_dim_counts.size(), m_total_count,
+         m_total_span, path);
+
+        register_transport_dbg_func([&](tlm::tlm_generic_payload& txn) -> unsigned int {
+            if (txn.get_data_length() < sizeof(ELEM)) return 0u;
+            uint64_t addr = txn.get_address();
+            uint64_t byte_off = proxy_data_array<ELEM>::p_relative_addresses.get_value()
+                                    ? addr
+                                    : addr - proxy_data_array<ELEM>::p_offset.get_value();
+            if (!byte_offset_is_element(byte_off)) return 0u;
+            unsigned char* data = txn.get_data_ptr();
+            if (txn.get_command() == tlm::TLM_READ_COMMAND) {
+                ELEM tmp;
+                proxy_data_array<ELEM>::get_bytes(&tmp, byte_off);
+                memset(data, 0, txn.get_data_length());
+                memcpy(data, &tmp, sizeof(ELEM));
+                return static_cast<unsigned int>(sizeof(ELEM));
+            }
+            if (txn.get_command() == tlm::TLM_WRITE_COMMAND) {
+                ELEM tmp;
+                memcpy(&tmp, data, sizeof(ELEM));
+                proxy_data_array<ELEM>::set_bytes(&tmp, byte_off);
+                return static_cast<unsigned int>(sizeof(ELEM));
+            }
+            return 0u;
+        });
+    }
+
+public:
+    gs_register() = delete;
+
+    /** 1D constructor. */
+    gs_register(std::string _name, std::string path, uint64_t offset, uint64_t count, uint64_t stride = sizeof(ELEM),
+                ELEM mask = gs_full_mask<ELEM>())
+        : m_regname(_name)
+        , m_path(path)
+        , port_fnct(_name, path)
+        , proxy_data_array<ELEM>(SCP_LOGGER_NAME(), _name, path, offset, count, mask, stride,
+                                 (count == 0 ? 0 : stride * (count - 1) + sizeof(ELEM)))
+    {
+        m_dim_counts = { count };
+        m_dim_strides = { stride };
+        init_common(_name, path);
+    }
+
+    /** N-D constructor. strides[0] is outermost; strides.back() innermost. */
+    gs_register(std::string _name, std::string path, uint64_t offset, std::vector<uint64_t> counts,
+                std::vector<uint64_t> strides, ELEM mask = gs_full_mask<ELEM>())
+        : m_regname(_name)
+        , m_path(path)
+        , port_fnct(_name, path)
+        , proxy_data_array<ELEM>(SCP_LOGGER_NAME(), _name, path, offset, compute_total_count(counts), mask,
+                                 (strides.empty() ? sizeof(ELEM) : strides.back()), compute_total_span(counts, strides))
+    {
+        if (counts.size() != strides.size() || counts.empty())
+            SCP_FATAL(())("bank {} constructor: counts and strides must have equal, non-zero size", _name);
+        for (uint64_t count : counts) {
+            if (count == 0) SCP_FATAL(())("bank {} constructor: dimension counts must be non-zero", _name);
+        }
+        m_dim_counts = std::move(counts);
+        m_dim_strides = std::move(strides);
+        init_common(_name, path);
+    }
+
+    gs_register_bank_element<ELEM> operator[](size_t i)
+    {
+        if (i >= m_dim_counts[0])
+            SCP_FATAL(())("bank {} dim 0 index {} exceeds count {}", m_regname, i, m_dim_counts[0]);
+        return gs_register_bank_element<ELEM>(*this, m_dim_strides, m_dim_counts, i * m_dim_strides[0], 1);
+    }
+
+    template <class... Idx, typename = std::enable_if_t<(sizeof...(Idx) >= 1) && (std::is_integral<Idx>::value && ...)>>
+    gs_register_bank_element<ELEM> operator()(Idx... indices)
+    {
+        const uint64_t idx_arr[] = { static_cast<uint64_t>(indices)... };
+        return build_cursor(idx_arr, sizeof...(Idx));
+    }
+
+    gs_register_bank_element<ELEM> at(std::initializer_list<uint64_t> indices)
+    {
+        return build_cursor(indices.begin(), indices.size());
+    }
+    gs_register_bank_element<ELEM> at(const std::vector<uint64_t>& indices)
+    {
+        return build_cursor(indices.data(), indices.size());
+    }
+
+private:
+    gs_register_bank_element<ELEM> build_cursor(const uint64_t* indices, size_t n)
+    {
+        if (n == 0 || n > m_dim_strides.size())
+            SCP_FATAL(())("bank {} indexed with {} dims, expected 1..{}", m_regname, n, m_dim_strides.size());
+        uint64_t off = 0;
+        for (size_t k = 0; k < n; k++) {
+            if (indices[k] >= m_dim_counts[k])
+                SCP_FATAL(())("bank {} index {} at dim {} exceeds count {}", m_regname, indices[k], k, m_dim_counts[k]);
+            off += indices[k] * m_dim_strides[k];
+        }
+        return gs_register_bank_element<ELEM>(*this, m_dim_strides, m_dim_counts, off, n);
+    }
+
+public:
+    // Bulk access by flat row-major index. For a 1D bank this uses the fast
+    // contiguous path when stride == sizeof(ELEM); otherwise it loops per
+    // element via the byte-offset path.
+    void get(ELEM* dst, uint64_t idx, uint64_t length)
+    {
+        if (m_dim_counts.size() == 1) {
+            proxy_data_array<ELEM>::get(dst, idx, length);
+        } else {
+            for (uint64_t i = 0; i < length; i++)
+                proxy_data_array<ELEM>::get_bytes(&dst[i], byte_offset_for_flat(idx + i));
+        }
+    }
+    void set(ELEM* src, uint64_t idx, uint64_t length, bool use_mask = true)
+    {
+        if (m_dim_counts.size() == 1 && m_element_masks.empty()) {
+            proxy_data_array<ELEM>::set(src, idx, length, use_mask);
+        } else {
+            for (uint64_t i = 0; i < length; i++)
+                proxy_data_array<ELEM>::set_bytes(&src[i], byte_offset_for_flat(idx + i), use_mask);
+        }
+    }
+
+    std::string get_regname() const { return m_regname; }
+    std::string get_path() const { return m_path; }
+    uint64_t get_offset() const { return proxy_data_array<ELEM>::p_offset.get_value(); }
+    uint64_t get_size() const { return proxy_data_array<ELEM>::p_size.get_value(); }
+    uint64_t get_total_count() const { return m_total_count; }
+    size_t get_dims() const { return m_dim_counts.size(); }
+    uint64_t get_dim_count(size_t k) const { return m_dim_counts.at(k); }
+    uint64_t get_dim_stride(size_t k) const { return m_dim_strides.at(k); }
+    const std::vector<uint64_t>& get_dim_counts() const { return m_dim_counts; }
+    const std::vector<uint64_t>& get_dim_strides() const { return m_dim_strides; }
+    ELEM get_mask() const { return proxy_data_array<ELEM>::p_mask.get_value(); }
+    void set_mask(ELEM mask) { proxy_data_array<ELEM>::p_mask = mask; }
+
+    void set_element_mask(uint64_t flat_index, ELEM mask)
+    {
+        if (flat_index >= m_total_count)
+            SCP_FATAL(())("bank {} flat index {} exceeds total count {}", m_regname, flat_index, m_total_count);
+        m_element_masks[flat_index] = mask;
+    }
+
+    ELEM get_element_mask(uint64_t flat_index) const
+    {
+        if (flat_index >= m_total_count)
+            SCP_FATAL(())("bank {} flat index {} exceeds total count {}", m_regname, flat_index, m_total_count);
+        return mask_for_element(flat_index);
+    }
+
+    void clear_element_mask(uint64_t flat_index)
+    {
+        if (flat_index >= m_total_count)
+            SCP_FATAL(())("bank {} flat index {} exceeds total count {}", m_regname, flat_index, m_total_count);
+        m_element_masks.erase(flat_index);
+    }
+
+    void set_element_mask(std::initializer_list<uint64_t> indices, ELEM mask)
+    {
+        set_element_mask(flat_index_for_indices(indices.begin(), indices.size()), mask);
+    }
+
+    ELEM get_element_mask(std::initializer_list<uint64_t> indices) const
+    {
+        return get_element_mask(flat_index_for_indices(indices.begin(), indices.size()));
+    }
+
+    void clear_element_mask(std::initializer_list<uint64_t> indices)
+    {
+        clear_element_mask(flat_index_for_indices(indices.begin(), indices.size()));
+    }
+
+    void set_element_mask(const std::vector<uint64_t>& indices, ELEM mask)
+    {
+        set_element_mask(flat_index_for_indices(indices.data(), indices.size()), mask);
+    }
+
+    ELEM get_element_mask(const std::vector<uint64_t>& indices) const
+    {
+        return get_element_mask(flat_index_for_indices(indices.data(), indices.size()));
+    }
+
+    void clear_element_mask(const std::vector<uint64_t>& indices)
+    {
+        clear_element_mask(flat_index_for_indices(indices.data(), indices.size()));
+    }
+
+protected:
+    bool has_element_masks() const override { return !m_element_masks.empty(); }
+
+    ELEM mask_for_element(uint64_t flat_index) const override
+    {
+        auto it = m_element_masks.find(flat_index);
+        return it == m_element_masks.end() ? proxy_data_array<ELEM>::p_mask.get_value() : it->second;
+    }
+
+    ELEM mask_for_byte_offset(uint64_t byte_offset) const override
+    {
+        uint64_t flat_index = 0;
+        if (!try_flat_index_for_byte_offset(byte_offset, flat_index)) return proxy_data_array<ELEM>::p_mask.get_value();
+        return mask_for_element(flat_index);
+    }
+
+public:
+    uint64_t byte_offset_for(const uint64_t* indices, size_t n) const
+    {
+        if (n != m_dim_strides.size())
+            SCP_FATAL(())("bank {} indexed with {} dims, expected {}", m_regname, n, m_dim_strides.size());
+        uint64_t off = 0;
+        for (size_t k = 0; k < n; k++) {
+            if (indices[k] >= m_dim_counts[k])
+                SCP_FATAL(())("bank {} index {} at dim {} exceeds count {}", m_regname, indices[k], k, m_dim_counts[k]);
+            off += indices[k] * m_dim_strides[k];
+        }
+        return off;
+    }
+
+    uint64_t byte_offset_for_flat(uint64_t flat_idx) const
+    {
+        if (flat_idx >= m_total_count)
+            SCP_FATAL(())("bank {} flat index {} exceeds total count {}", m_regname, flat_idx, m_total_count);
+        uint64_t off = 0;
+        uint64_t remaining = flat_idx;
+        for (size_t k = 0; k < m_dim_counts.size(); k++) {
+            uint64_t idx_k = remaining / m_row_major_div[k];
+            remaining = remaining % m_row_major_div[k];
+            off += idx_k * m_dim_strides[k];
+        }
+        return off;
+    }
+
+    bool is_element_start(const gs_bank_access& access) const
+    {
+        return access && byte_offset_for_flat(access.index) == access.byte_offset;
+    }
+
+    uint64_t masked_transaction_element_count(const tlm::tlm_generic_payload& txn, const gs_bank_access& access) const
+    {
+        if (!is_element_start(access)) return 0;
+        uint64_t length = txn.get_data_length();
+        if (length == 0 || length % sizeof(ELEM) != 0) return 0;
+
+        uint64_t count = length / sizeof(ELEM);
+        if (count == 1) return count;
+        if (m_dim_counts.size() != 1 || m_dim_strides[0] != sizeof(ELEM)) return 0;
+        if (access.index >= m_total_count || count > m_total_count - access.index) return 0;
+        return count;
+    }
+
+    bool byte_offset_is_element(uint64_t byte_off) const
+    {
+        uint64_t r = byte_off;
+        for (size_t k = 0; k < m_dim_strides.size(); k++) {
+            uint64_t idx = r / m_dim_strides[k];
+            if (idx >= m_dim_counts[k]) return false;
+            r = r % m_dim_strides[k];
+        }
+        return r < sizeof(ELEM);
+    }
+
+    /** Decode a transaction's address into per-dim indices; bool == on-element. */
+    gs_bank_access decode_access(const tlm::tlm_generic_payload& txn) const
+    {
+        gs_bank_access r{};
+        const uint64_t base = proxy_data_array<ELEM>::p_offset.get_value();
+        const bool relative = proxy_data_array<ELEM>::p_relative_addresses.get_value();
+        uint64_t addr = txn.get_address();
+        r.byte_offset = relative ? addr : (addr - base);
+
+        r.indices.assign(m_dim_strides.size(), 0);
+        uint64_t rem = r.byte_offset;
+        r.in_range = true;
+        for (size_t k = 0; k < m_dim_strides.size(); k++) {
+            uint64_t idx_k = rem / m_dim_strides[k];
+            rem = rem % m_dim_strides[k];
+            r.indices[k] = idx_k;
+            if (idx_k >= m_dim_counts[k]) r.in_range = false;
+        }
+        r.aligned = rem < sizeof(ELEM);
+
+        uint64_t flat = 0;
+        for (size_t k = 0; k < m_dim_strides.size(); k++) flat += r.indices[k] * m_row_major_div[k];
+        r.index = flat;
+        return r;
+    }
+
+    void capture_txn_pre(tlm::tlm_generic_payload& txn) override
+    {
+        if ((!has_element_masks() && proxy_data_array<ELEM>::p_mask.get_value() == gs_full_mask<ELEM>()) ||
+            (txn.get_command() != tlm::tlm_command::TLM_WRITE_COMMAND)) {
+            return;
+        }
+        auto a = decode_access(txn);
+        uint64_t count = masked_transaction_element_count(txn, a);
+        if (count == 0) {
+            captured_txn_data.clear();
+            txn.set_response_status(tlm::TLM_BURST_ERROR_RESPONSE);
+            return;
+        }
+        captured_txn_data.resize(count * sizeof(ELEM));
+        for (uint64_t i = 0; i < count; i++) {
+            proxy_data_array<ELEM>::get_bytes(reinterpret_cast<ELEM*>(captured_txn_data.data()) + i,
+                                              byte_offset_for_flat(a.index + i));
+        }
+    }
+
+    void handle_mask_post(tlm::tlm_generic_payload& txn) override
+    {
+        if ((!has_element_masks() && proxy_data_array<ELEM>::p_mask.get_value() == gs_full_mask<ELEM>()) ||
+            (txn.get_command() != tlm::tlm_command::TLM_WRITE_COMMAND)) {
+            return;
+        }
+        auto a = decode_access(txn);
+        uint64_t count = masked_transaction_element_count(txn, a);
+        if (count == 0 || captured_txn_data.size() < count * sizeof(ELEM)) {
+            txn.set_response_status(tlm::TLM_BURST_ERROR_RESPONSE);
+            return;
+        }
+        unsigned char* txn_data_ptr = txn.get_data_ptr();
+        for (uint64_t i = 0; i < count; i++) {
+            ELEM incoming;
+            ELEM stored;
+            memcpy(&incoming, txn_data_ptr + i * sizeof(ELEM), sizeof(ELEM));
+            memcpy(&stored, captured_txn_data.data() + i * sizeof(ELEM), sizeof(ELEM));
+            proxy_data_array<ELEM>::write_with_mask(&incoming, &stored, 1, get_element_mask(a.index + i));
+            proxy_data_array<ELEM>::set_bytes(&stored, byte_offset_for_flat(a.index + i), false);
+            memcpy(txn_data_ptr + i * sizeof(ELEM), &stored, sizeof(ELEM));
+        }
+    }
+
+protected:
+    using port_fnct::parent;
+};
 
 } // namespace gs
 

--- a/systemc-components/common/include/router_if.h
+++ b/systemc-components/common/include/router_if.h
@@ -17,6 +17,7 @@
 #include <tlm_sockets_buswidth.h>
 #include <string>
 #include <memory>
+#include <vector>
 
 namespace gs {
 template <unsigned int BUSWIDTH = DEFAULT_TLM_BUSWIDTH>
@@ -56,6 +57,29 @@ public:
         bool is_callback;
         bool chained;
         std::string shortname;
+        // 1D bank fields (used when dim_strides is empty).
+        // stride == 0 means plain range (scalar / contiguous register).
+        sc_dt::uint64 stride = 0;
+        sc_dt::uint64 elem_size = 0;
+        // N-D bank layout, outer dim first. Non-empty overrides the 1D fields.
+        std::vector<sc_dt::uint64> dim_strides;
+        std::vector<sc_dt::uint64> dim_counts;
+
+        bool claims(sc_dt::uint64 addr) const
+        {
+            if (addr < address || (addr - address) >= size) return false;
+            if (!dim_strides.empty()) {
+                sc_dt::uint64 r = addr - address;
+                for (size_t k = 0; k < dim_strides.size(); k++) {
+                    sc_dt::uint64 idx = r / dim_strides[k];
+                    if (idx >= dim_counts[k]) return false;
+                    r = r % dim_strides[k];
+                }
+                return r < elem_size;
+            }
+            if (stride == 0) return true;
+            return ((addr - address) % stride) < elem_size;
+        }
     };
 
     void rename_last(std::string s)

--- a/systemc-components/reg_router/include/reg_router.h
+++ b/systemc-components/reg_router/include/reg_router.h
@@ -201,6 +201,9 @@ public:
     }
 #endif
 
+    // Priority semantics match router.h: lower numeric value = higher priority
+    // (0 is strongest, default when unset). Callbacks fan out to all peers at
+    // the strongest priority; equal-priority mem targets are a fatal collision.
     bool do_callbacks(tlm::tlm_generic_payload& trans, sc_core::sc_time& delay)
     {
         if (cb_targets.empty()) {
@@ -208,32 +211,35 @@ public:
         }
 
         sc_dt::uint64 addr = trans.get_address();
-        sc_dt::uint64 len = trans.get_data_length();
-        std::shared_ptr<target_info> ti; // Use shared_ptr
 
-        auto search = cb_targets.equal_range(addr);
-        if (search.first != cb_targets.end() && search.first->first == addr) {
-            if ((addr - search.first->first) < search.first->second->size) {
-                ti = search.first->second;
+        std::vector<std::shared_ptr<target_info>> claimants;
+        uint32_t best_prio = 0;
+        for (auto& kv : cb_targets) {
+            const auto& cand = kv.second;
+            if (!cand->claims(addr)) continue;
+            if (claimants.empty() || cand->priority < best_prio) {
+                claimants.clear();
+                claimants.push_back(cand);
+                best_prio = cand->priority;
+            } else if (cand->priority == best_prio) {
+                claimants.push_back(cand);
             }
-        } else if (search.second != cb_targets.begin()) {
-            auto expected_node = std::prev(search.second);
-            if ((addr - expected_node->first) < expected_node->second->size) {
-                ti = expected_node->second;
-            } else {
-                return false;
-            }
-        } else {
-            return false;
         }
-        SCP_TRACEALL(()) << "call b_transport: " << txn_to_str(trans, true, true);
-        if (ti->use_offset) trans.set_address(addr - ti->address);
-        initiator_socket[ti->index]->b_transport(trans, delay);
-        if (ti->use_offset) trans.set_address(addr);
-        SCP_TRACEALL(()) << "b_transport returned : " << txn_to_str(trans, true, true);
-        if (trans.get_response_status() <= tlm::TLM_GENERIC_ERROR_RESPONSE) {
-            SCP_WARN(()) << "Accesing register callback at addr: " << std::hex << addr
-                         << " returned with: " << trans.get_response_string();
+
+        if (claimants.empty()) return false;
+
+        for (const auto& ti : claimants) {
+            SCP_TRACEALL(()) << "call b_transport (fan-out prio " << best_prio
+                             << "): " << txn_to_str(trans, true, true);
+            if (ti->use_offset) trans.set_address(addr - ti->address);
+            initiator_socket[ti->index]->b_transport(trans, delay);
+            if (ti->use_offset) trans.set_address(addr);
+            SCP_TRACEALL(()) << "b_transport returned : " << txn_to_str(trans, true, true);
+            if (trans.get_response_status() <= tlm::TLM_GENERIC_ERROR_RESPONSE) {
+                SCP_WARN(()) << "Accesing register callback at addr: " << std::hex << addr << " (target " << ti->name
+                             << ") returned with: " << trans.get_response_string();
+                break;
+            }
         }
         return true;
     }
@@ -243,14 +249,16 @@ public:
         lazy_initialize();
 
         sc_dt::uint64 addr = trans.get_address();
-        sc_dt::uint64 len = trans.get_data_length();
 
-        for (auto ti : mem_targets) { // Iterate over shared_ptrs
-            if (addr >= ti->address && (addr - ti->address) < ti->size) {
-                return ti;
-            }
+        std::shared_ptr<target_info> best;
+        for (auto& ti : mem_targets) {
+            if (!ti->claims(addr)) continue;
+            if (!best || ti->priority < best->priority)
+                best = ti;
+            else if (ti->priority == best->priority && ti != best)
+                SCP_FATAL(()) << "Two targets with equal priority both claim address 0x" << std::hex << addr;
         }
-        return nullptr;
+        return best;
     }
 
 protected:
@@ -260,6 +268,44 @@ protected:
     }
 
 protected:
+    static std::vector<sc_dt::uint64> parse_u64_csv(const std::string& s)
+    {
+        std::vector<sc_dt::uint64> out;
+        size_t i = 0;
+        while (i < s.size()) {
+            while (i < s.size() && (s[i] == ' ' || s[i] == ',')) ++i;
+            if (i >= s.size()) break;
+            size_t consumed = 0;
+            sc_dt::uint64 v = std::stoull(s.substr(i), &consumed, 0);
+            out.push_back(v);
+            i += consumed;
+        }
+        return out;
+    }
+
+    // Walk a's element grid and return true iff any byte of an element is claimed by b.
+    // O(prod(a.counts) * elem_size) at bind time; fine at elaboration.
+    static bool banks_element_overlap(const std::shared_ptr<target_info>& a, const std::shared_ptr<target_info>& b)
+    {
+        const auto& s = a->dim_strides.empty() ? std::vector<sc_dt::uint64>{ a->stride } : a->dim_strides;
+        const auto& c = a->dim_counts.empty() ? std::vector<sc_dt::uint64>{ 1 } : a->dim_counts;
+        std::vector<size_t> idx(s.size(), 0);
+        while (true) {
+            sc_dt::uint64 off = 0;
+            for (size_t k = 0; k < s.size(); k++) off += idx[k] * s[k];
+            for (sc_dt::uint64 byte = 0; byte < a->elem_size; byte++) {
+                if (b->claims(a->address + off + byte)) return true;
+            }
+            size_t k = s.size();
+            while (k-- > 0) {
+                if (++idx[k] < c[k]) break;
+                idx[k] = 0;
+                if (k == 0) return false;
+            }
+            if (k == (size_t)-1) return false;
+        }
+    }
+
     void lazy_initialize() override
     {
         if (initialized) return;
@@ -273,28 +319,47 @@ protected:
             ti_ptr->size = gs::cci_get<uint64_t>(m_broker, name + ".size");
             ti_ptr->use_offset = gs::cci_get_d<bool>(m_broker, name + ".relative_addresses", true);
             ti_ptr->is_callback = gs::cci_get_d<bool>(m_broker, name + ".is_callback", false);
-            ti_ptr->priority = gs::cci_get_d<uint32_t>(m_broker, name + ".priority", 0); // Added missing priority
+            ti_ptr->priority = gs::cci_get_d<uint32_t>(m_broker, name + ".priority", 0);
+            ti_ptr->stride = gs::cci_get_d<uint64_t>(m_broker, name + ".stride", 0);
+            ti_ptr->elem_size = gs::cci_get_d<uint64_t>(m_broker, name + ".elem_size", 0);
 
-            SCP_INFO(()) << "Address map " << ti_ptr->name + " at" << " address "
-                         << "0x" << std::hex << ti_ptr->address << " size "
-                         << "0x" << std::hex << ti_ptr->size << (ti_ptr->use_offset ? " (with relative address) " : "")
+            std::string strides_str = gs::cci_get_d<std::string>(m_broker, name + ".dim_strides", std::string());
+            std::string counts_str = gs::cci_get_d<std::string>(m_broker, name + ".dim_counts", std::string());
+            if (!strides_str.empty() && !counts_str.empty()) {
+                ti_ptr->dim_strides = parse_u64_csv(strides_str);
+                ti_ptr->dim_counts = parse_u64_csv(counts_str);
+                if (ti_ptr->dim_strides.size() != ti_ptr->dim_counts.size())
+                    SCP_FATAL(()) << name << " has mismatched dim_strides / dim_counts";
+            }
+
+            SCP_INFO(()) << "Address map " << ti_ptr->name + " at" << " address " << "0x" << std::hex << ti_ptr->address
+                         << " size " << "0x" << std::hex << ti_ptr->size
+                         << (ti_ptr->stride ? " stride 0x" + std::to_string(ti_ptr->stride) : "")
+                         << (ti_ptr->dim_strides.empty() ? "" : (" dims=" + std::to_string(ti_ptr->dim_strides.size())))
+                         << (ti_ptr->use_offset ? " (with relative address) " : "")
                          << (ti_ptr->is_callback ? " (callback) " : "");
 
             if (ti_ptr->is_callback) {
-                auto insertion_pair = cb_targets.insert(std::make_pair(ti_ptr->address, ti_ptr)); // Insert shared_ptr
-                if (!insertion_pair.second)
-                    SCP_FATAL(()) << "a CB register with the same adress: 0x" << std::hex << ti_ptr->address
-                                  << " was already bound!";
+                cb_targets.insert(std::make_pair(ti_ptr->address, ti_ptr));
             } else {
                 if (!mem_targets.empty()) {
-                    for (const auto& mem : mem_targets) { // Iterate over shared_ptrs
-                        if (((ti_ptr->address >= mem->address) && ((ti_ptr->address - mem->address) < mem->size)) ||
-                            ((ti_ptr->address < mem->address) && ((ti_ptr->address + ti_ptr->size) > mem->address))) {
+                    for (const auto& mem : mem_targets) {
+                        bool overlaps_range = ((ti_ptr->address >= mem->address) &&
+                                               ((ti_ptr->address - mem->address) < mem->size)) ||
+                                              ((ti_ptr->address < mem->address) &&
+                                               ((ti_ptr->address + ti_ptr->size) > mem->address));
+                        if (!overlaps_range) continue;
+
+                        bool ti_gapped = ti_ptr->stride != 0 || !ti_ptr->dim_strides.empty();
+                        bool mem_gapped = mem->stride != 0 || !mem->dim_strides.empty();
+                        if (!ti_gapped || !mem_gapped) {
                             SCP_WARN(()) << ti_ptr->name << " overlaps with " << mem->name;
+                        } else if (banks_element_overlap(ti_ptr, mem)) {
+                            SCP_WARN(()) << ti_ptr->name << " element footprint overlaps with " << mem->name;
                         }
                     }
                 }
-                mem_targets.push_back(ti_ptr); // Add shared_ptr
+                mem_targets.push_back(ti_ptr);
             }
         }
     }
@@ -338,7 +403,7 @@ public:
 
 private:
     std::vector<std::shared_ptr<target_info>> mem_targets;
-    std::map<sc_dt::uint64, std::shared_ptr<target_info>> cb_targets;
+    std::multimap<sc_dt::uint64, std::shared_ptr<target_info>> cb_targets;
     std::map<uint64_t, std::pair<uint64_t, std::string>> mod_addr_name_map;
     std::function<void(bool, uint64_t)> m_pre_b_transport_callback;
     bool initialized = false;

--- a/systemc-components/smmu500/include/smmu500.h
+++ b/systemc-components/smmu500/include/smmu500.h
@@ -122,20 +122,20 @@ private:
 
     void smmu500_update_ctx_irq(unsigned int cb)
     {
-        bool tf = (*SMMU_CB_FSR[cb])[CB_FSR_TF];
-        bool ie = (*SMMU_CB_SCTLR[cb])[CB_SCTLR_CFIE];
+        bool tf = SMMU_CB_FSR[cb][CB_FSR_TF];
+        bool ie = SMMU_CB_SCTLR[cb][CB_SCTLR_CFIE];
         irq_context[cb]->write(tf && ie);
     }
 
     void smmu500_fault(unsigned int cb, TransReq* req, uint64_t syn)
     {
-        (*SMMU_CB_FSR[cb])[CB_FSR_TF] = 1;
+        SMMU_CB_FSR[cb][CB_FSR_TF] = 1;
         req->err = true;
-        *SMMU_CB_IPAFAR_LOW[cb] = (uint32_t)req->va;
-        *SMMU_CB_IPAFAR_HIGH[cb] = (uint32_t)(req->va >> 32);
+        SMMU_CB_IPAFAR_LOW[cb] = (uint32_t)req->va;
+        SMMU_CB_IPAFAR_HIGH[cb] = (uint32_t)(req->va >> 32);
         if (req->stage == 2) {
-            *SMMU_CB_FAR_LOW[cb] = (uint32_t)req->va;
-            *SMMU_CB_FAR_HIGH[cb] = (uint32_t)(req->va >> 32);
+            SMMU_CB_FAR_LOW[cb] = (uint32_t)req->va;
+            SMMU_CB_FAR_HIGH[cb] = (uint32_t)(req->va >> 32);
         }
         smmu500_update_ctx_irq(cb);
     }
@@ -193,18 +193,18 @@ private:
     void dump_cb_state(unsigned int cb)
     {
         SCP_DEBUG(()) << "CB" << cb << ":\n"
-                      << std::hex << "CB_SCTLR = 0x" << (uint32_t)*SMMU_CB_SCTLR[cb] << "\n"
-                      << "CB_TCR2 = 0x" << (uint32_t)*SMMU_CB_TCR2[cb] << "\n"
-                      << "CB_TTBR0_LOW = 0x" << (uint32_t)*SMMU_CB_TTBR0_LOW[cb] << "\n"
-                      << "CB_TTBR0_HIGH = 0x" << (uint32_t)*SMMU_CB_TTBR0_HIGH[cb] << "\n"
-                      << "CB_TTBR1_LOW = 0x" << (uint32_t)*SMMU_CB_TTBR1_LOW[cb] << "\n"
-                      << "CB_TTBR1_HIGH = 0x" << (uint32_t)*SMMU_CB_TTBR1_HIGH[cb] << "\n"
-                      << "CB_TCR_LPAE = 0x" << (uint32_t)*SMMU_CB_TCR_LPAE[cb] << "\n"
-                      << "CB_FSR = 0x" << (uint32_t)*SMMU_CB_FSR[cb] << "\n"
-                      << "CB_FAR_LOW = 0x" << (uint32_t)*SMMU_CB_FAR_LOW[cb] << "\n"
-                      << "CB_FAR_HIGH = 0x" << (uint32_t)*SMMU_CB_FAR_HIGH[cb] << "\n"
-                      << "CB_IPAFAR_LOW = 0x" << (uint32_t)*SMMU_CB_IPAFAR_LOW[cb] << "\n"
-                      << "CB_IPAFAR_HIGH = 0x" << (uint32_t)*SMMU_CB_IPAFAR_HIGH[cb] << "\n";
+                      << std::hex << "CB_SCTLR = 0x" << (uint32_t)SMMU_CB_SCTLR[cb] << "\n"
+                      << "CB_TCR2 = 0x" << (uint32_t)SMMU_CB_TCR2[cb] << "\n"
+                      << "CB_TTBR0_LOW = 0x" << (uint32_t)SMMU_CB_TTBR0_LOW[cb] << "\n"
+                      << "CB_TTBR0_HIGH = 0x" << (uint32_t)SMMU_CB_TTBR0_HIGH[cb] << "\n"
+                      << "CB_TTBR1_LOW = 0x" << (uint32_t)SMMU_CB_TTBR1_LOW[cb] << "\n"
+                      << "CB_TTBR1_HIGH = 0x" << (uint32_t)SMMU_CB_TTBR1_HIGH[cb] << "\n"
+                      << "CB_TCR_LPAE = 0x" << (uint32_t)SMMU_CB_TCR_LPAE[cb] << "\n"
+                      << "CB_FSR = 0x" << (uint32_t)SMMU_CB_FSR[cb] << "\n"
+                      << "CB_FAR_LOW = 0x" << (uint32_t)SMMU_CB_FAR_LOW[cb] << "\n"
+                      << "CB_FAR_HIGH = 0x" << (uint32_t)SMMU_CB_FAR_HIGH[cb] << "\n"
+                      << "CB_IPAFAR_LOW = 0x" << (uint32_t)SMMU_CB_IPAFAR_LOW[cb] << "\n"
+                      << "CB_IPAFAR_HIGH = 0x" << (uint32_t)SMMU_CB_IPAFAR_HIGH[cb] << "\n";
     }
 
     void dump_state()
@@ -250,11 +250,11 @@ private:
 
         req->err = false;
 
-        if ((*SMMU_CB_SCTLR[cb])[CB_SCTLR_M] == 0) {
+        if (SMMU_CB_SCTLR[cb][CB_SCTLR_M] == 0) {
             req->pa = req->va;
             req->prot = IOMMU_RW;
             SCP_INFO(()) << "SMMU disabled for context " << cb << " sctlr=0x" << std::hex
-                         << (uint32_t)*SMMU_CB_SCTLR[cb];
+                         << (uint32_t)SMMU_CB_SCTLR[cb];
             return;
         }
 
@@ -357,8 +357,8 @@ private:
                 s2req.va = descaddr;
                 smmu500_ptw64(s2req.s2_cb, &s2req);
                 if (s2req.err) {
-                    *SMMU_CB_IPAFAR_LOW[cb] = (uint32_t)descaddr;
-                    *SMMU_CB_IPAFAR_HIGH[cb] = (uint32_t)(descaddr >> 32);
+                    SMMU_CB_IPAFAR_LOW[cb] = (uint32_t)descaddr;
+                    SMMU_CB_IPAFAR_HIGH[cb] = (uint32_t)(descaddr >> 32);
                     goto do_fault;
                 }
                 descaddr = s2req.pa;
@@ -513,23 +513,23 @@ private:
         }
 
         req.va = va;
-        req.tcr[1] = (uint32_t)*SMMU_CB_TCR2[cb];
+        req.tcr[1] = (uint32_t)SMMU_CB_TCR2[cb];
         req.tcr[1] <<= 32;
-        req.tcr[1] |= (uint32_t)*SMMU_CB_TCR_LPAE[cb];
+        req.tcr[1] |= (uint32_t)SMMU_CB_TCR_LPAE[cb];
 
-        req.ttbr[1][0] = (uint32_t)*SMMU_CB_TTBR0_HIGH[cb];
+        req.ttbr[1][0] = (uint32_t)SMMU_CB_TTBR0_HIGH[cb];
         req.ttbr[1][0] <<= 32;
-        req.ttbr[1][0] |= (uint32_t)*SMMU_CB_TTBR0_LOW[cb];
+        req.ttbr[1][0] |= (uint32_t)SMMU_CB_TTBR0_LOW[cb];
 
-        req.ttbr[1][1] = (uint32_t)*SMMU_CB_TTBR1_HIGH[cb];
+        req.ttbr[1][1] = (uint32_t)SMMU_CB_TTBR1_HIGH[cb];
         req.ttbr[1][1] <<= 32;
-        req.ttbr[1][1] |= (uint32_t)*SMMU_CB_TTBR1_LOW[cb];
+        req.ttbr[1][1] |= (uint32_t)SMMU_CB_TTBR1_LOW[cb];
 
         if (req.s2_enabled) {
-            req.tcr[2] = (uint32_t)*SMMU_CB_TCR_LPAE[s2_cb];
-            req.ttbr[2][0] = (uint32_t)*SMMU_CB_TTBR0_HIGH[s2_cb];
+            req.tcr[2] = (uint32_t)SMMU_CB_TCR_LPAE[s2_cb];
+            req.ttbr[2][0] = (uint32_t)SMMU_CB_TTBR0_HIGH[s2_cb];
             req.ttbr[2][0] <<= 32;
-            req.ttbr[2][0] |= (uint32_t)*SMMU_CB_TTBR0_LOW[s2_cb];
+            req.ttbr[2][0] |= (uint32_t)SMMU_CB_TTBR0_LOW[s2_cb];
         }
 
         req.access = wr ? IOMMU_WO : IOMMU_RO;

--- a/systemc-components/smmu500/include/smmu500_gen.h
+++ b/systemc-components/smmu500/include/smmu500_gen.h
@@ -8,8 +8,7 @@
 #define smmu500_gen_H
 
 #include <reg_model_maker/reg_model_maker.h>
-#include <vector>
-#include <memory>
+#include <cstdint>
 #include <string>
 
 namespace gs {
@@ -19,6 +18,9 @@ private:
     std::string m_name;
 
 public:
+    static constexpr uint32_t CB_BANK_COUNT = 128;
+    using reg_bank = gs::gs_register<gs::gs_bank_of<uint32_t>>;
+
     gs::gs_register<uint32_t> SMMU_SCR0;
     gs::gs_field<uint32_t> SCR0_CLIENTPD;
     gs::gs_register<uint32_t> SMMU_NSCR0;
@@ -58,29 +60,29 @@ public:
     gs::gs_register<uint32_t> SMMU_GPAR;
     gs::gs_register<uint32_t> SMMU_GPAR_H;
     gs::gs_register<uint32_t> SMMU_TBU_PWR_STATUS;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_SCTLR;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_ACTLR;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_RESUME;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_TCR2;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_TTBR0_LOW;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_TTBR0_HIGH;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_TTBR1_LOW;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_TTBR1_HIGH;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_TCR_LPAE;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_CONTEXTIDR;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_PRRR_MAIR0;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_NMRR_MAIR1;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_FSR;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_FSRRESTORE;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_FAR_LOW;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_FAR_HIGH;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_FSYNR0;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_IPAFAR_LOW;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_IPAFAR_HIGH;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_TLBIASID;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_TLBIALL;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_TLBSYNC;
-    std::vector<std::shared_ptr<gs::gs_register<uint32_t>>> SMMU_CB_TLBSTATUS;
+    reg_bank SMMU_CB_SCTLR;
+    reg_bank SMMU_CB_ACTLR;
+    reg_bank SMMU_CB_RESUME;
+    reg_bank SMMU_CB_TCR2;
+    reg_bank SMMU_CB_TTBR0_LOW;
+    reg_bank SMMU_CB_TTBR0_HIGH;
+    reg_bank SMMU_CB_TTBR1_LOW;
+    reg_bank SMMU_CB_TTBR1_HIGH;
+    reg_bank SMMU_CB_TCR_LPAE;
+    reg_bank SMMU_CB_CONTEXTIDR;
+    reg_bank SMMU_CB_PRRR_MAIR0;
+    reg_bank SMMU_CB_NMRR_MAIR1;
+    reg_bank SMMU_CB_FSR;
+    reg_bank SMMU_CB_FSRRESTORE;
+    reg_bank SMMU_CB_FAR_LOW;
+    reg_bank SMMU_CB_FAR_HIGH;
+    reg_bank SMMU_CB_FSYNR0;
+    reg_bank SMMU_CB_IPAFAR_LOW;
+    reg_bank SMMU_CB_IPAFAR_HIGH;
+    reg_bank SMMU_CB_TLBIASID;
+    reg_bank SMMU_CB_TLBIALL;
+    reg_bank SMMU_CB_TLBSYNC;
+    reg_bank SMMU_CB_TLBSTATUS;
 
     /* CB register fields (parent reg is a placeholder for bit_start/bit_length only) */
     gs::gs_field<uint32_t> CB_SCTLR_M;
@@ -128,10 +130,60 @@ public:
         , SMMU_GPAR("SMMU_GPAR", "smmu500.SMMU_GPAR", 0x180, 1)
         , SMMU_GPAR_H("SMMU_GPAR_H", "smmu500.SMMU_GPAR_H", 0x184, 1)
         , SMMU_TBU_PWR_STATUS("SMMU_TBU_PWR_STATUS", "smmu500.SMMU_TBU_PWR_STATUS", 0x2204, 1)
+        , SMMU_CB_SCTLR("SMMU_CB_SCTLR", "smmu500.SMMU_CB_SCTLR", 0x000, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_ACTLR("SMMU_CB_ACTLR", "smmu500.SMMU_CB_ACTLR", 0x004, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_RESUME("SMMU_CB_RESUME", "smmu500.SMMU_CB_RESUME", 0x008, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_TCR2("SMMU_CB_TCR2", "smmu500.SMMU_CB_TCR2", 0x010, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_TTBR0_LOW("SMMU_CB_TTBR0_LOW", "smmu500.SMMU_CB_TTBR0_LOW", 0x020, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_TTBR0_HIGH("SMMU_CB_TTBR0_HIGH", "smmu500.SMMU_CB_TTBR0_HIGH", 0x024, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_TTBR1_LOW("SMMU_CB_TTBR1_LOW", "smmu500.SMMU_CB_TTBR1_LOW", 0x028, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_TTBR1_HIGH("SMMU_CB_TTBR1_HIGH", "smmu500.SMMU_CB_TTBR1_HIGH", 0x02C, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_TCR_LPAE("SMMU_CB_TCR_LPAE", "smmu500.SMMU_CB_TCR_LPAE", 0x030, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_CONTEXTIDR("SMMU_CB_CONTEXTIDR", "smmu500.SMMU_CB_CONTEXTIDR", 0x034, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_PRRR_MAIR0("SMMU_CB_PRRR_MAIR0", "smmu500.SMMU_CB_PRRR_MAIR0", 0x038, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_NMRR_MAIR1("SMMU_CB_NMRR_MAIR1", "smmu500.SMMU_CB_NMRR_MAIR1", 0x03C, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_FSR("SMMU_CB_FSR", "smmu500.SMMU_CB_FSR", 0x058, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_FSRRESTORE("SMMU_CB_FSRRESTORE", "smmu500.SMMU_CB_FSRRESTORE", 0x05C, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_FAR_LOW("SMMU_CB_FAR_LOW", "smmu500.SMMU_CB_FAR_LOW", 0x060, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_FAR_HIGH("SMMU_CB_FAR_HIGH", "smmu500.SMMU_CB_FAR_HIGH", 0x064, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_FSYNR0("SMMU_CB_FSYNR0", "smmu500.SMMU_CB_FSYNR0", 0x068, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_IPAFAR_LOW("SMMU_CB_IPAFAR_LOW", "smmu500.SMMU_CB_IPAFAR_LOW", 0x070, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_IPAFAR_HIGH("SMMU_CB_IPAFAR_HIGH", "smmu500.SMMU_CB_IPAFAR_HIGH", 0x074, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_TLBIASID("SMMU_CB_TLBIASID", "smmu500.SMMU_CB_TLBIASID", 0x610, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_TLBIALL("SMMU_CB_TLBIALL", "smmu500.SMMU_CB_TLBIALL", 0x618, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_TLBSYNC("SMMU_CB_TLBSYNC", "smmu500.SMMU_CB_TLBSYNC", 0x7F0, CB_BANK_COUNT, 0x1000ULL)
+        , SMMU_CB_TLBSTATUS("SMMU_CB_TLBSTATUS", "smmu500.SMMU_CB_TLBSTATUS", 0x7F4, CB_BANK_COUNT, 0x1000ULL)
         , CB_SCTLR_M(SMMU_SCR0, "CB_SCTLR.M", 0, 1)
         , CB_SCTLR_CFIE(SMMU_SCR0, "CB_SCTLR.CFIE", 6, 1)
         , CB_FSR_TF(SMMU_SGFSR, "CB_FSR.TF", 1, 1)
     {
+    }
+
+    void set_cb_bank_base(uint64_t base)
+    {
+        SMMU_CB_SCTLR.p_offset = base + 0x000;
+        SMMU_CB_ACTLR.p_offset = base + 0x004;
+        SMMU_CB_RESUME.p_offset = base + 0x008;
+        SMMU_CB_TCR2.p_offset = base + 0x010;
+        SMMU_CB_TTBR0_LOW.p_offset = base + 0x020;
+        SMMU_CB_TTBR0_HIGH.p_offset = base + 0x024;
+        SMMU_CB_TTBR1_LOW.p_offset = base + 0x028;
+        SMMU_CB_TTBR1_HIGH.p_offset = base + 0x02C;
+        SMMU_CB_TCR_LPAE.p_offset = base + 0x030;
+        SMMU_CB_CONTEXTIDR.p_offset = base + 0x034;
+        SMMU_CB_PRRR_MAIR0.p_offset = base + 0x038;
+        SMMU_CB_NMRR_MAIR1.p_offset = base + 0x03C;
+        SMMU_CB_FSR.p_offset = base + 0x058;
+        SMMU_CB_FSRRESTORE.p_offset = base + 0x05C;
+        SMMU_CB_FAR_LOW.p_offset = base + 0x060;
+        SMMU_CB_FAR_HIGH.p_offset = base + 0x064;
+        SMMU_CB_FSYNR0.p_offset = base + 0x068;
+        SMMU_CB_IPAFAR_LOW.p_offset = base + 0x070;
+        SMMU_CB_IPAFAR_HIGH.p_offset = base + 0x074;
+        SMMU_CB_TLBIASID.p_offset = base + 0x610;
+        SMMU_CB_TLBIALL.p_offset = base + 0x618;
+        SMMU_CB_TLBSYNC.p_offset = base + 0x7F0;
+        SMMU_CB_TLBSTATUS.p_offset = base + 0x7F4;
     }
 
     void bind_regs(gs::json_module& jm)
@@ -160,6 +212,29 @@ public:
         jm.bind_reg(SMMU_GPAR);
         jm.bind_reg(SMMU_GPAR_H);
         jm.bind_reg(SMMU_TBU_PWR_STATUS);
+        jm.bind_reg(SMMU_CB_SCTLR);
+        jm.bind_reg(SMMU_CB_ACTLR);
+        jm.bind_reg(SMMU_CB_RESUME);
+        jm.bind_reg(SMMU_CB_TCR2);
+        jm.bind_reg(SMMU_CB_TTBR0_LOW);
+        jm.bind_reg(SMMU_CB_TTBR0_HIGH);
+        jm.bind_reg(SMMU_CB_TTBR1_LOW);
+        jm.bind_reg(SMMU_CB_TTBR1_HIGH);
+        jm.bind_reg(SMMU_CB_TCR_LPAE);
+        jm.bind_reg(SMMU_CB_CONTEXTIDR);
+        jm.bind_reg(SMMU_CB_PRRR_MAIR0);
+        jm.bind_reg(SMMU_CB_NMRR_MAIR1);
+        jm.bind_reg(SMMU_CB_FSR);
+        jm.bind_reg(SMMU_CB_FSRRESTORE);
+        jm.bind_reg(SMMU_CB_FAR_LOW);
+        jm.bind_reg(SMMU_CB_FAR_HIGH);
+        jm.bind_reg(SMMU_CB_FSYNR0);
+        jm.bind_reg(SMMU_CB_IPAFAR_LOW);
+        jm.bind_reg(SMMU_CB_IPAFAR_HIGH);
+        jm.bind_reg(SMMU_CB_TLBIASID);
+        jm.bind_reg(SMMU_CB_TLBIALL);
+        jm.bind_reg(SMMU_CB_TLBSYNC);
+        jm.bind_reg(SMMU_CB_TLBSTATUS);
         jm.log_end_of_binding_msg(m_name);
     }
 };

--- a/systemc-components/smmu500/src/smmu500.cc
+++ b/systemc-components/smmu500/src/smmu500.cc
@@ -17,13 +17,6 @@ INCBIN(ZipArchive_smmu500_, __FILE__ "_config.zip");
 
 namespace gs {
 
-static std::string make_cb_reg_name(const std::string& prefix, int cb) { return prefix + std::to_string(cb); }
-
-static std::string make_cb_reg_path(const std::string& prefix, int cb)
-{
-    return "smmu500." + prefix + std::to_string(cb);
-}
-
 template <unsigned int BUSWIDTH>
 smmu500<BUSWIDTH>::smmu500(sc_core::sc_module_name _name)
     : sc_core::sc_module(_name)
@@ -47,46 +40,8 @@ smmu500<BUSWIDTH>::smmu500(sc_core::sc_module_name _name)
 {
     SCP_TRACE(())("Constructor");
     sc_assert(loaded_ok);
+    set_cb_bank_base(static_cast<uint64_t>(p_num_pages) * SMMU_PAGESIZE);
     bind_regs(M);
-
-    /* Create per-CB page registers */
-    for (int cb = 0; cb < p_num_cb; cb++) {
-        uint32_t cb_base = (p_num_pages + cb) * SMMU_PAGESIZE;
-
-#define MAKE_CB_REG(vec, suffix, offset)                                                                           \
-    do {                                                                                                           \
-        auto rn = make_cb_reg_name("SMMU_CB_" suffix, cb);                                                         \
-        auto rp = make_cb_reg_path("SMMU_CB_" suffix, cb);                                                         \
-        vec.push_back(std::make_shared<gs::gs_register<uint32_t>>(rn.c_str(), rp.c_str(), cb_base + (offset), 1)); \
-        M.bind_reg(*vec.back());                                                                                   \
-    } while (0)
-
-        MAKE_CB_REG(SMMU_CB_SCTLR, "SCTLR", 0x0);
-        MAKE_CB_REG(SMMU_CB_ACTLR, "ACTLR", 0x4);
-        MAKE_CB_REG(SMMU_CB_RESUME, "RESUME", 0x8);
-        MAKE_CB_REG(SMMU_CB_TCR2, "TCR2", 0x10);
-        MAKE_CB_REG(SMMU_CB_TTBR0_LOW, "TTBR0_LOW", 0x20);
-        MAKE_CB_REG(SMMU_CB_TTBR0_HIGH, "TTBR0_HIGH", 0x24);
-        MAKE_CB_REG(SMMU_CB_TTBR1_LOW, "TTBR1_LOW", 0x28);
-        MAKE_CB_REG(SMMU_CB_TTBR1_HIGH, "TTBR1_HIGH", 0x2c);
-        MAKE_CB_REG(SMMU_CB_TCR_LPAE, "TCR_LPAE", 0x30);
-        MAKE_CB_REG(SMMU_CB_CONTEXTIDR, "CONTEXTIDR", 0x34);
-        MAKE_CB_REG(SMMU_CB_PRRR_MAIR0, "PRRR_MAIR0", 0x38);
-        MAKE_CB_REG(SMMU_CB_NMRR_MAIR1, "NMRR_MAIR1", 0x3c);
-        MAKE_CB_REG(SMMU_CB_FSR, "FSR", 0x58);
-        MAKE_CB_REG(SMMU_CB_FSRRESTORE, "FSRRESTORE", 0x5c);
-        MAKE_CB_REG(SMMU_CB_FAR_LOW, "FAR_LOW", 0x60);
-        MAKE_CB_REG(SMMU_CB_FAR_HIGH, "FAR_HIGH", 0x64);
-        MAKE_CB_REG(SMMU_CB_FSYNR0, "FSYNR0", 0x68);
-        MAKE_CB_REG(SMMU_CB_IPAFAR_LOW, "IPAFAR_LOW", 0x70);
-        MAKE_CB_REG(SMMU_CB_IPAFAR_HIGH, "IPAFAR_HIGH", 0x74);
-        MAKE_CB_REG(SMMU_CB_TLBIASID, "TLBIASID", 0x610);
-        MAKE_CB_REG(SMMU_CB_TLBIALL, "TLBIALL", 0x618);
-        MAKE_CB_REG(SMMU_CB_TLBSYNC, "TLBSYNC", 0x7f0);
-        MAKE_CB_REG(SMMU_CB_TLBSTATUS, "TLBSTATUS", 0x7f4);
-
-#undef MAKE_CB_REG
-    }
 
     socket.bind(M.target_socket);
     reset.register_value_changed_cb([&](bool value) {
@@ -139,40 +94,33 @@ void smmu500<BUSWIDTH>::before_end_of_elaboration()
     SMMU_NSCR0.post_write([this](TXN(txn)) { SMMU_SCR0 = (uint32_t)SMMU_NSCR0; });
 
     /* Per-CB callbacks */
-    for (int cb = 0; cb < p_num_cb; cb++) {
-        /* FSR post_write - update context IRQs for all CBs */
-        SMMU_CB_FSR[cb]->post_write([this](TXN(txn)) {
-            for (unsigned int i = 0; i < p_num_cb; i++) smmu500_update_ctx_irq(i);
-        });
+    /* FSR post_write - update context IRQs for all CBs */
+    SMMU_CB_FSR.post_write([this](TXN(txn)) {
+        const auto access = SMMU_CB_FSR.decode_access(txn);
+        if (!access || access.indices.size() != 1 || access.indices[0] >= p_num_cb) return;
+        for (unsigned int i = 0; i < p_num_cb; i++) smmu500_update_ctx_irq(i);
+    });
 
-        /* TLBIASID post_write - TLB flush by value */
-        SMMU_CB_TLBIASID[cb]->post_write([this](TXN(txn)) {
-            uint32_t val = *(uint32_t*)txn.get_data_ptr();
-            for (auto tbu : tbus) {
-                tbu->start_invalidates();
-            }
-            for (auto tbu : tbus) {
-                tbu->invalidate(val);
-            }
-            for (auto tbu : tbus) {
-                tbu->stop_invalidates();
-            }
-        });
+    /* TLBIASID post_write - TLB flush by value */
+    SMMU_CB_TLBIASID.post_write([this](TXN(txn)) {
+        const auto access = SMMU_CB_TLBIASID.decode_access(txn);
+        if (!access || access.indices.size() != 1 || access.indices[0] >= p_num_cb) return;
+        uint32_t val = *(uint32_t*)txn.get_data_ptr();
+        for (auto tbu : tbus) tbu->start_invalidates();
+        for (auto tbu : tbus) tbu->invalidate(val);
+        for (auto tbu : tbus) tbu->stop_invalidates();
+    });
 
-        /* TLBIALL post_write - TLB flush all for this CB */
-        SMMU_CB_TLBIALL[cb]->post_write([this, cb](TXN(txn)) {
-            SCP_DEBUG(()) << "TLBIALL write for CB" << cb;
-            for (auto tbu : tbus) {
-                tbu->start_invalidates();
-            }
-            for (auto tbu : tbus) {
-                tbu->invalidate(cb);
-            }
-            for (auto tbu : tbus) {
-                tbu->stop_invalidates();
-            }
-        });
-    }
+    /* TLBIALL post_write - TLB flush all for this CB */
+    SMMU_CB_TLBIALL.post_write([this](TXN(txn)) {
+        const auto access = SMMU_CB_TLBIALL.decode_access(txn);
+        if (!access || access.indices.size() != 1 || access.indices[0] >= p_num_cb) return;
+        const unsigned int cb = static_cast<unsigned int>(access.indices[0]);
+        SCP_DEBUG(()) << "TLBIALL write for CB" << cb;
+        for (auto tbu : tbus) tbu->start_invalidates();
+        for (auto tbu : tbus) tbu->invalidate(cb);
+        for (auto tbu : tbus) tbu->stop_invalidates();
+    });
 }
 
 template class smmu500<32>;

--- a/tests/components/gs_register/gs_register-bench.h
+++ b/tests/components/gs_register/gs_register-bench.h
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-
 #include <systemc>
 #include <tlm>
 #include <tlm_utils/simple_initiator_socket.h>
@@ -30,11 +29,46 @@ protected:
     gs::gs_field<uint32_t> CMD0_OPCODE;
     gs::gs_field<uint32_t> CMD0_PARAM;
     gs::gs_register<uint64_t> STATUS64;
+    gs::gs_register<gs::gs_bank_of<uint32_t>> BANK1D;
+    gs::gs_register<gs::gs_bank_of<uint32_t>> BANK_GAP;
+    gs::gs_register<gs::gs_bank_of<uint32_t>> BANK2D;
+    gs::gs_register<gs::gs_bank_of<uint64_t>> BANK64;
+    gs::gs_register<uint32_t> ALIAS_A;
+    gs::gs_register<uint32_t> ALIAS_B;
+    gs::gs_register<gs::gs_bank_of<uint32_t>> BANK3D_A;
+    gs::gs_register<gs::gs_bank_of<uint32_t>> BANK3D_B;
+    gs::gs_register<uint32_t> LOWPRI;
+    gs::gs_register<gs::gs_bank_of<uint32_t>> SHADOW;
+    gs::gs_field<uint32_t> BANK1D_STATUS_DESC;
+    gs::gs_field<uint32_t> BANK2D_STATUS;
+    gs::gs_field<uint32_t> BANK2D_PAYLOAD;
+    gs::gs_field<uint32_t> BANK2D_STATUS_DESC;
+    gs::gs_field<uint64_t> BANK64_FULL;
+    gs::gs_field<uint32_t> B3D_LO;
+    gs::gs_field<uint32_t> B3D_HI;
+
     uint32_t last_written_value;
     uint64_t last_written_idx;
     uint32_t last_used_mask;
     std::vector<uint32_t> last_read_vec;
     bool is_array;
+
+    // Bank callback observation.
+    int bank1d_pre_writes;
+    int bank1d_post_writes;
+    int bank1d_pre_reads;
+    int bank_gap_pre_writes;
+    int bank2d_post_writes;
+    uint64_t bank2d_last_write_addr;
+    int alias_a_hits;
+    int alias_b_hits;
+    int bank3d_a_hits;
+    int bank3d_b_hits;
+    uint64_t bank3d_a_last_rel_addr;
+    uint64_t bank3d_b_last_rel_addr;
+    int lowpri_hits;
+    int shadow_hits;
+    uint64_t shadow_last_rel_addr;
 
 public:
     RegisterTestBench(const sc_core::sc_module_name& n);

--- a/tests/components/gs_register/gs_register-tests.cc
+++ b/tests/components/gs_register/gs_register-tests.cc
@@ -15,6 +15,38 @@
 #define CMD0_LEN      1UL
 #define STATUS64_ADDR 0x200UL
 #define STATUS64_LEN  1UL
+#define BANK64_ADDR   0x280UL
+
+#define BANK1D_ADDR   0x300UL
+#define BANK1D_LEN    4UL
+#define BANK1D_STRIDE 4UL
+
+#define BANK_GAP_ADDR   0x400UL
+#define BANK_GAP_LEN    4UL
+#define BANK_GAP_STRIDE 8UL
+
+#define BANK2D_ADDR       0x500UL
+#define BANK2D_ROWS       3UL
+#define BANK2D_COLS       4UL
+#define BANK2D_ROW_STRIDE 0x10UL
+#define BANK2D_COL_STRIDE 0x4UL
+
+#define ALIAS_ADDR 0x800UL
+
+#define BANK3D_A_ADDR 0x900UL
+#define BANK3D_B_ADDR 0x904UL
+#define BANK3D_D0     2UL
+#define BANK3D_D1     2UL
+#define BANK3D_D2     2UL
+#define BANK3D_S0     0x40UL
+#define BANK3D_S1     0x10UL
+#define BANK3D_S2     0x8UL
+
+#define LOWPRI_ADDR ALIAS_ADDR
+
+#define SHADOW_ADDR   0x0UL
+#define SHADOW_LEN    0x400UL
+#define SHADOW_STRIDE 4UL
 
 RegisterTestBench::RegisterTestBench(const sc_core::sc_module_name& n)
     : TestBench(n)
@@ -26,10 +58,45 @@ RegisterTestBench::RegisterTestBench(const sc_core::sc_module_name& n)
     , CMD0_OPCODE(CMD0, CMD0.get_regname() + ".OPCODE", 27UL, 5UL)
     , CMD0_PARAM(CMD0, CMD0.get_regname() + ".PARAM", 0UL, 27UL)
     , STATUS64("STATUS64", "STATUS64", STATUS64_ADDR, STATUS64_LEN)
+    , BANK1D("BANK1D", "BANK1D", BANK1D_ADDR, BANK1D_LEN, BANK1D_STRIDE)
+    , BANK_GAP("BANK_GAP", "BANK_GAP", BANK_GAP_ADDR, BANK_GAP_LEN, BANK_GAP_STRIDE)
+    , BANK2D("BANK2D", "BANK2D", BANK2D_ADDR, std::vector<uint64_t>{ BANK2D_ROWS, BANK2D_COLS },
+             std::vector<uint64_t>{ BANK2D_ROW_STRIDE, BANK2D_COL_STRIDE })
+    , BANK64("BANK64", "BANK64", BANK64_ADDR, 1UL)
+    , ALIAS_A("ALIAS_A", "ALIAS_A", ALIAS_ADDR, 1UL)
+    , ALIAS_B("ALIAS_B", "ALIAS_B", ALIAS_ADDR, 1UL)
+    , BANK3D_A("BANK3D_A", "BANK3D_A", BANK3D_A_ADDR, std::vector<uint64_t>{ BANK3D_D0, BANK3D_D1, BANK3D_D2 },
+               std::vector<uint64_t>{ BANK3D_S0, BANK3D_S1, BANK3D_S2 })
+    , BANK3D_B("BANK3D_B", "BANK3D_B", BANK3D_B_ADDR, std::vector<uint64_t>{ BANK3D_D0, BANK3D_D1, BANK3D_D2 },
+               std::vector<uint64_t>{ BANK3D_S0, BANK3D_S1, BANK3D_S2 })
+    , LOWPRI("LOWPRI", "LOWPRI", LOWPRI_ADDR, 1UL)
+    , SHADOW("SHADOW", "SHADOW", SHADOW_ADDR, SHADOW_LEN, SHADOW_STRIDE)
+    , BANK1D_STATUS_DESC(BANK1D, "BANK1D_STATUS_DESC", 8UL, 4UL)
+    , BANK2D_STATUS(BANK2D, "BANK2D_STATUS", 0UL, 4UL)
+    , BANK2D_PAYLOAD(BANK2D, "BANK2D_PAYLOAD", 4UL, 24UL)
+    , BANK2D_STATUS_DESC(BANK2D, "BANK2D_STATUS_DESC", 0UL, 4UL)
+    , BANK64_FULL(BANK64, "BANK64_FULL", 0UL, 64UL)
+    , B3D_LO(BANK3D_A, "B3D_LO", 0UL, 8UL)
+    , B3D_HI(BANK3D_A, "B3D_HI", 8UL, 16UL)
     , last_written_value(0)
     , last_written_idx(0)
     , last_used_mask(gs::gs_full_mask<uint32_t>())
     , is_array(false)
+    , bank1d_pre_writes(0)
+    , bank1d_post_writes(0)
+    , bank1d_pre_reads(0)
+    , bank_gap_pre_writes(0)
+    , bank2d_post_writes(0)
+    , bank2d_last_write_addr(0)
+    , alias_a_hits(0)
+    , alias_b_hits(0)
+    , bank3d_a_hits(0)
+    , bank3d_b_hits(0)
+    , bank3d_a_last_rel_addr(0)
+    , bank3d_b_last_rel_addr(0)
+    , lowpri_hits(0)
+    , shadow_hits(0)
+    , shadow_last_rel_addr(0)
 {
     m_initiator.socket.bind(m_reg_router.target_socket);
 
@@ -46,6 +113,46 @@ RegisterTestBench::RegisterTestBench(const sc_core::sc_module_name& n)
     STATUS64.initiator_socket.bind(m_reg_memory.socket);
     m_reg_router.initiator_socket.bind(STATUS64);
     m_reg_router.rename_last(std::string(this->name()) + ".STATUS64.target_socket");
+
+    BANK64.initiator_socket.bind(m_reg_memory.socket);
+    m_reg_router.initiator_socket.bind(BANK64);
+    m_reg_router.rename_last(std::string(this->name()) + ".BANK64.target_socket");
+
+    BANK1D.initiator_socket.bind(m_reg_memory.socket);
+    m_reg_router.initiator_socket.bind(BANK1D);
+    m_reg_router.rename_last(std::string(this->name()) + ".BANK1D.target_socket");
+
+    BANK_GAP.initiator_socket.bind(m_reg_memory.socket);
+    m_reg_router.initiator_socket.bind(BANK_GAP);
+    m_reg_router.rename_last(std::string(this->name()) + ".BANK_GAP.target_socket");
+
+    BANK2D.initiator_socket.bind(m_reg_memory.socket);
+    m_reg_router.initiator_socket.bind(BANK2D);
+    m_reg_router.rename_last(std::string(this->name()) + ".BANK2D.target_socket");
+
+    ALIAS_A.initiator_socket.bind(m_reg_memory.socket);
+    m_reg_router.initiator_socket.bind(ALIAS_A);
+    m_reg_router.rename_last(std::string(this->name()) + ".ALIAS_A.target_socket");
+
+    ALIAS_B.initiator_socket.bind(m_reg_memory.socket);
+    m_reg_router.initiator_socket.bind(ALIAS_B);
+    m_reg_router.rename_last(std::string(this->name()) + ".ALIAS_B.target_socket");
+
+    BANK3D_A.initiator_socket.bind(m_reg_memory.socket);
+    m_reg_router.initiator_socket.bind(BANK3D_A);
+    m_reg_router.rename_last(std::string(this->name()) + ".BANK3D_A.target_socket");
+
+    BANK3D_B.initiator_socket.bind(m_reg_memory.socket);
+    m_reg_router.initiator_socket.bind(BANK3D_B);
+    m_reg_router.rename_last(std::string(this->name()) + ".BANK3D_B.target_socket");
+
+    LOWPRI.initiator_socket.bind(m_reg_memory.socket);
+    m_reg_router.initiator_socket.bind(LOWPRI);
+    m_reg_router.rename_last(std::string(this->name()) + ".LOWPRI.target_socket");
+
+    SHADOW.initiator_socket.bind(m_reg_memory.socket);
+    m_reg_router.initiator_socket.bind(SHADOW);
+    m_reg_router.rename_last(std::string(this->name()) + ".SHADOW.target_socket");
 }
 
 void RegisterTestBench::end_of_elaboration()
@@ -95,6 +202,43 @@ void RegisterTestBench::end_of_elaboration()
 
     STATUS64.pre_write([&](tlm::tlm_generic_payload& trans, sc_core::sc_time& delay) {
         STATUS64.set_mask(0x0ULL); /*Read Only*/
+    });
+
+    BANK1D.pre_write([&](tlm::tlm_generic_payload& trans, sc_core::sc_time& delay) { bank1d_pre_writes++; });
+    BANK1D.post_write([&](tlm::tlm_generic_payload& trans, sc_core::sc_time& delay) {
+        bank1d_post_writes++;
+        auto a = BANK1D.decode_access(trans);
+        ASSERT_TRUE(static_cast<bool>(a));
+        ASSERT_EQ(a.indices.size(), 1u);
+    });
+    BANK1D.pre_read([&](tlm::tlm_generic_payload& trans, sc_core::sc_time& delay) { bank1d_pre_reads++; });
+
+    BANK_GAP.pre_write([&](tlm::tlm_generic_payload& trans, sc_core::sc_time& delay) { bank_gap_pre_writes++; });
+
+    BANK2D.post_write([&](tlm::tlm_generic_payload& trans, sc_core::sc_time& delay) {
+        bank2d_post_writes++;
+        bank2d_last_write_addr = trans.get_address();
+    });
+
+    ALIAS_A.post_write([&](tlm::tlm_generic_payload& trans, sc_core::sc_time& delay) { alias_a_hits++; });
+    ALIAS_B.post_write([&](tlm::tlm_generic_payload& trans, sc_core::sc_time& delay) { alias_b_hits++; });
+
+    // trans.get_address() inside the callback is the router-stripped relative
+    // offset (use_offset=true), so we record it as-is for later assertions.
+    BANK3D_A.post_write([&](tlm::tlm_generic_payload& trans, sc_core::sc_time& delay) {
+        bank3d_a_hits++;
+        bank3d_a_last_rel_addr = trans.get_address();
+    });
+    BANK3D_B.post_write([&](tlm::tlm_generic_payload& trans, sc_core::sc_time& delay) {
+        bank3d_b_hits++;
+        bank3d_b_last_rel_addr = trans.get_address();
+    });
+
+    LOWPRI.post_write([&](tlm::tlm_generic_payload& trans, sc_core::sc_time& delay) { lowpri_hits++; });
+
+    SHADOW.post_write([&](tlm::tlm_generic_payload& trans, sc_core::sc_time& delay) {
+        shadow_hits++;
+        shadow_last_rel_addr = trans.get_address();
     });
 }
 
@@ -269,6 +413,613 @@ TEST_BENCH(RegisterTestBench, test_registers)
                                               // register shouldn't change at write
 }
 
+TEST_BENCH(RegisterTestBench, test_registers_bank)
+{
+    SCP_DEBUG(()) << "**************** Register bank: shape metadata ****************";
+    ASSERT_EQ(BANK1D.get_regname(), "BANK1D");
+    ASSERT_EQ(BANK1D.get_offset(), BANK1D_ADDR);
+    ASSERT_EQ(BANK1D.get_dims(), 1u);
+    ASSERT_EQ(BANK1D.get_dim_count(0), BANK1D_LEN);
+    ASSERT_EQ(BANK1D.get_dim_stride(0), BANK1D_STRIDE);
+    ASSERT_EQ(BANK1D.get_total_count(), BANK1D_LEN);
+    // span = (n-1)*stride + sizeof(elem) = 3*4 + 4 = 16
+    ASSERT_EQ(BANK1D.get_size(), 3UL * BANK1D_STRIDE + sizeof(uint32_t));
+    ASSERT_EQ(BANK1D.get_mask(), gs::gs_full_mask<uint32_t>());
+
+    ASSERT_EQ(BANK_GAP.get_dim_stride(0), BANK_GAP_STRIDE);
+    // gapped span = 3*8 + 4 = 28
+    ASSERT_EQ(BANK_GAP.get_size(), 3UL * BANK_GAP_STRIDE + sizeof(uint32_t));
+
+    ASSERT_EQ(BANK2D.get_dims(), 2u);
+    ASSERT_EQ(BANK2D.get_dim_count(0), BANK2D_ROWS);
+    ASSERT_EQ(BANK2D.get_dim_count(1), BANK2D_COLS);
+    ASSERT_EQ(BANK2D.get_dim_stride(0), BANK2D_ROW_STRIDE);
+    ASSERT_EQ(BANK2D.get_dim_stride(1), BANK2D_COL_STRIDE);
+    ASSERT_EQ(BANK2D.get_total_count(), BANK2D_ROWS * BANK2D_COLS);
+    // span = (rows-1)*row_stride + (cols-1)*col_stride + sizeof(elem)
+    ASSERT_EQ(BANK2D.get_size(),
+              (BANK2D_ROWS - 1) * BANK2D_ROW_STRIDE + (BANK2D_COLS - 1) * BANK2D_COL_STRIDE + sizeof(uint32_t));
+
+    SCP_DEBUG(()) << "**************** BANK1D: element access via cursor ****************";
+    for (uint32_t i = 0; i < BANK1D_LEN; i++) {
+        BANK1D[i] = 0xDEAD0000UL | i;
+    }
+    for (uint32_t i = 0; i < BANK1D_LEN; i++) {
+        uint32_t v = BANK1D[i];
+        ASSERT_EQ(v, 0xDEAD0000UL | i);
+    }
+
+    // The corresponding memory bytes must reflect the writes at base + stride*i.
+    for (uint32_t i = 0; i < BANK1D_LEN; i++) {
+        uint32_t mem_v = 0;
+        m_initiator.do_read<uint32_t>(BANK1D_ADDR + BANK1D_STRIDE * i, mem_v);
+        ASSERT_EQ(mem_v, 0xDEAD0000UL | i);
+    }
+
+    SCP_DEBUG(()) << "**************** BANK1D: initiator writes reach the callback and DMI ****************";
+    int prev_pre = bank1d_pre_writes;
+    int prev_post = bank1d_post_writes;
+    m_initiator.do_write<uint32_t>(BANK1D_ADDR + BANK1D_STRIDE * 2, 0xCAFEBABEUL);
+    ASSERT_EQ(bank1d_pre_writes, prev_pre + 1);
+    ASSERT_EQ(bank1d_post_writes, prev_post + 1);
+    uint32_t v = BANK1D[2];
+    ASSERT_EQ(v, 0xCAFEBABEUL);
+
+    SCP_DEBUG(()) << "**************** BANK1D: RMW operators on cursor ****************";
+    BANK1D[0] = 10UL;
+    BANK1D[0] += 5UL;
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[0]), 15UL);
+    BANK1D[0] *= 2UL;
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[0]), 30UL);
+    BANK1D[0] /= 3UL;
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[0]), 10UL);
+    BANK1D[0] |= 0x1UL;
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[0]), 11UL);
+    BANK1D[0] &= 0x2UL;
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[0]), 2UL);
+    BANK1D[0] <<= 2UL;
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[0]), 8UL);
+    BANK1D[0] >>= 1UL;
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[0]), 4UL);
+    BANK1D[0] -= 4UL;
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[0]), 0UL);
+    BANK1D[0] ^= 0xF0F0UL;
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[0]), 0xF0F0UL);
+
+    SCP_DEBUG(()) << "**************** BANK1D: bit-field access on cursor ****************";
+    // CMD0_PARAM = bits [0, 27), CMD0_OPCODE = bits [27, 32). Reused only for their
+    // bit_start/bit_length metadata; they are unrelated to BANK1D otherwise.
+    BANK1D[1] = 0UL;
+    BANK1D[1][CMD0_PARAM] = 0x123456UL;
+    BANK1D[1][CMD0_OPCODE] = 0x1FUL;
+    uint32_t full = BANK1D[1];
+    ASSERT_EQ(full, (0x1FUL << 27) | 0x123456UL);
+    uint32_t param_readback = BANK1D[1][CMD0_PARAM];
+    uint32_t opcode_readback = BANK1D[1][CMD0_OPCODE];
+    ASSERT_EQ(param_readback, 0x123456UL);
+    ASSERT_EQ(opcode_readback, 0x1FUL);
+
+    SCP_DEBUG(()) << "**************** BANK1D: bulk set()/get() (contiguous path) ****************";
+    std::vector<uint32_t> src(BANK1D_LEN, 0);
+    for (uint32_t i = 0; i < BANK1D_LEN; i++) src[i] = 0xA0A0A000UL + i;
+    BANK1D.set(src.data(), 0, BANK1D_LEN);
+    std::vector<uint32_t> dst(BANK1D_LEN, 0);
+    BANK1D.get(dst.data(), 0, BANK1D_LEN);
+    for (uint32_t i = 0; i < BANK1D_LEN; i++) ASSERT_EQ(dst[i], 0xA0A0A000UL + i);
+
+    SCP_DEBUG(()) << "**************** BANK1D: mask / RMW via capture_txn_pre + handle_mask_post ****************";
+    // Prime element 3 with a known baseline, then write via initiator with a
+    // partial mask; the register must combine incoming bits masked-in with
+    // the previously stored bits.
+    BANK1D.set_mask(gs::gs_full_mask<uint32_t>());
+    BANK1D[3] = 0xAAAAAAAAUL;
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[3]), 0xAAAAAAAAUL);
+    BANK1D.set_mask(0x00FF00FFUL); // only low bytes of each 16-bit half writable
+    m_initiator.do_write<uint32_t>(BANK1D_ADDR + BANK1D_STRIDE * 3, 0x55555555UL);
+    // stored[3] = (0xAAAAAAAA & ~0x00FF00FF) | (0x55555555 & 0x00FF00FF)
+    //           = 0xAA00AA00 | 0x00550055 = 0xAA55AA55
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[3]), 0xAA55AA55UL);
+
+    SCP_DEBUG(()) << "**************** BANK1D: masked contiguous burst updates every element ****************";
+    BANK1D.set_mask(gs::gs_full_mask<uint32_t>());
+    BANK1D[0] = 0xAAAAAAAAUL;
+    BANK1D[1] = 0xBBBBBBBBUL;
+    BANK1D.set_mask(0x00FF00FFUL);
+    std::vector<uint32_t> masked_burst_data{ 0x55555555UL, 0x66666666UL };
+    tlm::tlm_generic_payload masked_burst;
+    masked_burst.set_command(tlm::TLM_WRITE_COMMAND);
+    masked_burst.set_address(BANK1D_ADDR);
+    masked_burst.set_data_ptr(reinterpret_cast<unsigned char*>(masked_burst_data.data()));
+    masked_burst.set_data_length(masked_burst_data.size() * sizeof(uint32_t));
+    masked_burst.set_streaming_width(masked_burst.get_data_length());
+    masked_burst.set_byte_enable_length(0);
+    masked_burst.set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
+    ASSERT_EQ(m_initiator.do_b_transport(masked_burst), tlm::TLM_OK_RESPONSE);
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[0]), 0xAA55AA55UL);
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[1]), 0xBB66BB66UL);
+    BANK1D.set_mask(gs::gs_full_mask<uint32_t>()); // restore
+
+    SCP_DEBUG(()) << "**************** BANK1D: transport_dbg on a bank element ****************";
+    BANK1D[0] = 0x11111111UL;
+    tlm::tlm_generic_payload dbg;
+    uint32_t dbg_val = 0;
+    dbg.set_command(tlm::TLM_READ_COMMAND);
+    dbg.set_address(BANK1D_ADDR + BANK1D_STRIDE * 0);
+    dbg.set_data_length(sizeof(uint32_t));
+    dbg.set_data_ptr(reinterpret_cast<unsigned char*>(&dbg_val));
+    dbg.set_streaming_width(sizeof(uint32_t));
+    unsigned int got = m_initiator.socket->transport_dbg(dbg);
+    // transport_dbg on the router hits gs_memory here; either path is fine so
+    // long as we read back the stored value.
+    ASSERT_GT(got, 0u);
+    ASSERT_EQ(dbg_val, 0x11111111UL);
+
+    SCP_DEBUG(()) << "**************** BANK_GAP: element vs gap addresses ****************";
+    // Element addresses: 0x400, 0x408, 0x410, 0x418. Gap addresses at +4 within
+    // each slot (0x404, 0x40C, 0x414, 0x41C) are inside the bank's span but must
+    // not fire the bank callback and must not be treated as an element by
+    // byte_offset_is_element / decode_access.
+    ASSERT_TRUE(BANK_GAP.byte_offset_is_element(0));
+    ASSERT_FALSE(BANK_GAP.byte_offset_is_element(4));
+    ASSERT_TRUE(BANK_GAP.byte_offset_is_element(8));
+    ASSERT_FALSE(BANK_GAP.byte_offset_is_element(12));
+
+    // Assign each element via cursor.
+    for (uint32_t i = 0; i < BANK_GAP_LEN; i++) {
+        BANK_GAP[i] = 0xB0B00000UL + i;
+    }
+    for (uint32_t i = 0; i < BANK_GAP_LEN; i++) {
+        uint32_t got_v = BANK_GAP[i];
+        ASSERT_EQ(got_v, 0xB0B00000UL + i);
+        uint32_t mem_v = 0;
+        m_initiator.do_read<uint32_t>(BANK_GAP_ADDR + BANK_GAP_STRIDE * i, mem_v);
+        ASSERT_EQ(mem_v, 0xB0B00000UL + i);
+    }
+
+    SCP_DEBUG(()) << "**************** BANK_GAP: gap-address writes bypass the bank callback ****************";
+    int gap_pre_before = bank_gap_pre_writes;
+    // Address 0x404 sits in the gap between elements 0 and 1. reg_router's
+    // claims() rejects it for BANK_GAP, so only reg_memory is reached.
+    m_initiator.do_write<uint32_t>(BANK_GAP_ADDR + 4UL, 0xDEADBEEFUL);
+    ASSERT_EQ(bank_gap_pre_writes, gap_pre_before); // callback did NOT fire
+    uint32_t gap_mem = 0;
+    m_initiator.do_read<uint32_t>(BANK_GAP_ADDR + 4UL, gap_mem);
+    ASSERT_EQ(gap_mem, 0xDEADBEEFUL); // memory still holds the byte
+
+    // The gap write must not perturb bank element 0 (still at its old value).
+    uint32_t elem0_after_gap_write = BANK_GAP[0];
+    ASSERT_EQ(elem0_after_gap_write, 0xB0B00000UL);
+
+    SCP_DEBUG(()) << "**************** BANK_GAP: masked burst is rejected ****************";
+    BANK_GAP.set_mask(gs::gs_full_mask<uint32_t>());
+    BANK_GAP[0] = 0xAAAAAAAAUL;
+    BANK_GAP[1] = 0xBBBBBBBBUL;
+    BANK_GAP.set_mask(0x00FF00FFUL);
+    std::vector<uint32_t> gapped_burst_data{ 0x55555555UL, 0x66666666UL };
+    tlm::tlm_generic_payload gapped_burst;
+    gapped_burst.set_command(tlm::TLM_WRITE_COMMAND);
+    gapped_burst.set_address(BANK_GAP_ADDR);
+    gapped_burst.set_data_ptr(reinterpret_cast<unsigned char*>(gapped_burst_data.data()));
+    gapped_burst.set_data_length(gapped_burst_data.size() * sizeof(uint32_t));
+    gapped_burst.set_streaming_width(gapped_burst.get_data_length());
+    gapped_burst.set_byte_enable_length(0);
+    gapped_burst.set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
+    ASSERT_EQ(m_initiator.do_b_transport(gapped_burst), tlm::TLM_BURST_ERROR_RESPONSE);
+    ASSERT_EQ(static_cast<uint32_t>(BANK_GAP[0]), 0xAAAAAAAAUL);
+    ASSERT_EQ(static_cast<uint32_t>(BANK_GAP[1]), 0xBBBBBBBBUL);
+    BANK_GAP.set_mask(gs::gs_full_mask<uint32_t>());
+
+    SCP_DEBUG(()) << "**************** BANK_GAP: decode_access on element and gap ****************";
+    // p_relative_addresses defaults to true, so decode_access consumes the
+    // relative offset - the router strips the base before the callback runs.
+    tlm::tlm_generic_payload probe;
+    probe.set_address(BANK_GAP_STRIDE * 2);
+    auto acc_elem = BANK_GAP.decode_access(probe);
+    ASSERT_TRUE(bool(acc_elem));
+    ASSERT_EQ(acc_elem.index, 2u);
+    ASSERT_EQ(acc_elem.indices.size(), 1u);
+    ASSERT_EQ(acc_elem.indices[0], 2u);
+
+    probe.set_address(BANK_GAP_STRIDE * 2 + 4);
+    auto acc_gap = BANK_GAP.decode_access(probe);
+    ASSERT_FALSE(bool(acc_gap));
+    ASSERT_FALSE(acc_gap.aligned);
+
+    SCP_DEBUG(()) << "**************** BANK_GAP: bulk get()/set() (strided path) ****************";
+    std::vector<uint32_t> gsrc(BANK_GAP_LEN, 0);
+    for (uint32_t i = 0; i < BANK_GAP_LEN; i++) gsrc[i] = 0xC0C00000UL + i;
+    BANK_GAP.set(gsrc.data(), 0, BANK_GAP_LEN);
+    std::vector<uint32_t> gdst(BANK_GAP_LEN, 0);
+    BANK_GAP.get(gdst.data(), 0, BANK_GAP_LEN);
+    for (uint32_t i = 0; i < BANK_GAP_LEN; i++) ASSERT_EQ(gdst[i], 0xC0C00000UL + i);
+
+    SCP_DEBUG(()) << "**************** BANK2D: element access via three index forms ****************";
+    // Write via bank[i][j], read via bank(i, j) and bank.at({i, j}) - all three
+    // must agree, and the underlying memory must be at row-major offset
+    // i*row_stride + j*col_stride.
+    for (uint32_t i = 0; i < BANK2D_ROWS; i++) {
+        for (uint32_t j = 0; j < BANK2D_COLS; j++) {
+            BANK2D[i][j] = 0x20000UL | (i << 8) | j;
+        }
+    }
+    for (uint32_t i = 0; i < BANK2D_ROWS; i++) {
+        for (uint32_t j = 0; j < BANK2D_COLS; j++) {
+            uint32_t expected = 0x20000UL | (i << 8) | j;
+            uint32_t via_paren = BANK2D(i, j);
+            uint32_t via_at_ilist = BANK2D.at({ (uint64_t)i, (uint64_t)j });
+            uint32_t via_at_vec = BANK2D.at(std::vector<uint64_t>{ i, j });
+            ASSERT_EQ(via_paren, expected);
+            ASSERT_EQ(via_at_ilist, expected);
+            ASSERT_EQ(via_at_vec, expected);
+            uint32_t mem_v = 0;
+            m_initiator.do_read<uint32_t>(BANK2D_ADDR + i * BANK2D_ROW_STRIDE + j * BANK2D_COL_STRIDE, mem_v);
+            ASSERT_EQ(mem_v, expected);
+        }
+    }
+
+    SCP_DEBUG(()) << "**************** BANK2D: alternate write forms are equivalent ****************";
+    BANK2D(2, 1) = 0xABCDEF01UL;
+    ASSERT_EQ(static_cast<uint32_t>(BANK2D[2][1]), 0xABCDEF01UL);
+    BANK2D.at({ 1, 3 }) = 0x02468ACEUL;
+    ASSERT_EQ(static_cast<uint32_t>(BANK2D[1][3]), 0x02468ACEUL);
+
+    SCP_DEBUG(()) << "**************** BANK2D: initiator write routes to the bank callback ****************";
+    int prev_2d_post = bank2d_post_writes;
+    uint64_t target_addr = BANK2D_ADDR + 2 * BANK2D_ROW_STRIDE + 3 * BANK2D_COL_STRIDE;
+    m_initiator.do_write<uint32_t>(target_addr, 0xFEEDFACEUL);
+    ASSERT_EQ(bank2d_post_writes, prev_2d_post + 1);
+    // The callback observes the router-stripped relative address (use_offset).
+    ASSERT_EQ(bank2d_last_write_addr, 2 * BANK2D_ROW_STRIDE + 3 * BANK2D_COL_STRIDE);
+    ASSERT_EQ(static_cast<uint32_t>(BANK2D(2, 3)), 0xFEEDFACEUL);
+
+    SCP_DEBUG(()) << "**************** BANK2D: byte_offset_for / byte_offset_for_flat ****************";
+    {
+        uint64_t idx2[2] = { 2, 3 };
+        ASSERT_EQ(BANK2D.byte_offset_for(idx2, 2), 2 * BANK2D_ROW_STRIDE + 3 * BANK2D_COL_STRIDE);
+        // Row-major flat: (i=2, j=3) -> 2 * COLS + 3 = 11
+        ASSERT_EQ(BANK2D.byte_offset_for_flat(2 * BANK2D_COLS + 3), 2 * BANK2D_ROW_STRIDE + 3 * BANK2D_COL_STRIDE);
+        ASSERT_TRUE(BANK2D.byte_offset_is_element(0));
+        ASSERT_TRUE(BANK2D.byte_offset_is_element((BANK2D_ROWS - 1) * BANK2D_ROW_STRIDE +
+                                                  (BANK2D_COLS - 1) * BANK2D_COL_STRIDE));
+    }
+
+    SCP_DEBUG(()) << "**************** BANK2D: decode_access returns per-dim indices ****************";
+    tlm::tlm_generic_payload probe2d;
+    // Relative address into the bank (router strips the base for callbacks).
+    probe2d.set_address(1 * BANK2D_ROW_STRIDE + 2 * BANK2D_COL_STRIDE);
+    auto acc2d = BANK2D.decode_access(probe2d);
+    ASSERT_TRUE(bool(acc2d));
+    ASSERT_EQ(acc2d.indices.size(), 2u);
+    ASSERT_EQ(acc2d.indices[0], 1u);
+    ASSERT_EQ(acc2d.indices[1], 2u);
+    // Row-major flat: 1 * COLS + 2 = 6
+    ASSERT_EQ(acc2d.index, 1u * BANK2D_COLS + 2u);
+
+    SCP_DEBUG(()) << "**************** BANK2D: bulk get()/set() (row-major flat) ****************";
+    const uint64_t total = BANK2D_ROWS * BANK2D_COLS;
+    std::vector<uint32_t> b2d_src(total, 0);
+    for (uint64_t k = 0; k < total; k++) b2d_src[k] = 0x30000UL + static_cast<uint32_t>(k);
+    BANK2D.set(b2d_src.data(), 0, total);
+    std::vector<uint32_t> b2d_dst(total, 0);
+    BANK2D.get(b2d_dst.data(), 0, total);
+    for (uint64_t k = 0; k < total; k++) ASSERT_EQ(b2d_dst[k], 0x30000UL + static_cast<uint32_t>(k));
+    // And the per-element positions must match the row-major flat mapping.
+    for (uint32_t i = 0; i < BANK2D_ROWS; i++) {
+        for (uint32_t j = 0; j < BANK2D_COLS; j++) {
+            uint32_t v_cursor = BANK2D[i][j];
+            ASSERT_EQ(v_cursor, 0x30000UL + static_cast<uint32_t>(i * BANK2D_COLS + j));
+        }
+    }
+
+    SCP_DEBUG(()) << "**************** BANK2D: bitfield access on a bank element ****************";
+    // Seed element (1,2) with a known value, then read and write fields.
+    BANK2D[1][2] = 0x00000000UL;
+    // Write STATUS=0xA, PAYLOAD=0x123456 -> bits[27:4]=0x123456, bits[3:0]=0xA
+    // stored value = (0x123456 << 4) | 0xA = 0x0123456A
+    BANK2D[1][2][BANK2D_STATUS] = 0xAu;
+    BANK2D[1][2][BANK2D_PAYLOAD] = 0x123456u;
+    uint32_t elem_val = BANK2D[1][2];
+    ASSERT_EQ(elem_val, 0x0123456AUL);
+
+    // Read each field back independently.
+    uint32_t status_val = BANK2D[1][2][BANK2D_STATUS];
+    uint32_t payload_val = BANK2D[1][2][BANK2D_PAYLOAD];
+    ASSERT_EQ(status_val, 0xAu);
+    ASSERT_EQ(payload_val, 0x123456u);
+
+    SCP_DEBUG(()) << "**************** BANK fields: bank-owned descriptors ****************";
+    BANK1D[1] = 0x00000000UL;
+    BANK1D[1][BANK1D_STATUS_DESC] = 0xAu;
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[1]), 0x00000A00UL);
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[1][BANK1D_STATUS_DESC]), 0xAu);
+
+    BANK2D[0][3] = 0x00000000UL;
+    BANK2D[0][3][BANK2D_STATUS_DESC] = 0x5u;
+    ASSERT_EQ(static_cast<uint32_t>(BANK2D[0][3]), 0x5u);
+    ASSERT_EQ(static_cast<uint32_t>(BANK2D[0][3][BANK2D_STATUS_DESC]), 0x5u);
+
+    // RMW: update only STATUS, leave PAYLOAD intact.
+    BANK2D[1][2][BANK2D_STATUS] = 0x5u;
+    ASSERT_EQ(static_cast<uint32_t>(BANK2D[1][2]), 0x01234565UL);
+    ASSERT_EQ(static_cast<uint32_t>(BANK2D[1][2][BANK2D_PAYLOAD]), 0x123456u);
+
+    SCP_DEBUG(()) << "**************** BANK64: full-width field access ****************";
+    BANK64[0] = 0;
+    BANK64[0][BANK64_FULL] = 0xFEDCBA9876543210ULL;
+    ASSERT_EQ(static_cast<uint64_t>(BANK64[0]), 0xFEDCBA9876543210ULL);
+    ASSERT_EQ(static_cast<uint64_t>(BANK64[0][BANK64_FULL]), 0xFEDCBA9876543210ULL);
+
+    // Same test on a 3D element via BANK3D_A[i][j][k][field].
+    BANK3D_A[0][0][0] = 0xDEADC0DEul; // sentinel: must survive adjacent field writes
+    BANK3D_A[0][1][0] = 0x00000000UL;
+    BANK3D_A[0][1][0][B3D_LO] = 0xABu;
+    BANK3D_A[0][1][0][B3D_HI] = 0xCDEFu;
+    uint32_t b3d_val = BANK3D_A[0][1][0];
+    ASSERT_EQ(b3d_val, 0x00CDEFABUL);
+    ASSERT_EQ(static_cast<uint32_t>(BANK3D_A[0][1][0][B3D_LO]), 0xABu);
+    ASSERT_EQ(static_cast<uint32_t>(BANK3D_A[0][1][0][B3D_HI]), 0xCDEFu);
+
+    // Neighbouring element must be untouched by the field writes above.
+    ASSERT_EQ(static_cast<uint32_t>(BANK3D_A[0][0][0]), 0xDEADC0DEul);
+
+    SCP_DEBUG(()) << "**************** Router: fan-out to two callbacks at the same address ****************";
+    // ALIAS_A and ALIAS_B are both cb_targets at ALIAS_ADDR with default priority
+    // 0. reg_router's do_callbacks must invoke BOTH per transaction (once at
+    // pre-, once at post-, so each register's post_write CB fires once per
+    // initiator write). LOWPRI shares the address at priority 1 and is filtered
+    // out - the router keeps only the strongest-priority claimants.
+    int a_before = alias_a_hits;
+    int b_before = alias_b_hits;
+    int lowpri_before = lowpri_hits;
+    m_initiator.do_write<uint32_t>(ALIAS_ADDR, 0x77777777UL);
+    ASSERT_EQ(alias_a_hits, a_before + 1);
+    ASSERT_EQ(alias_b_hits, b_before + 1);
+    ASSERT_EQ(lowpri_hits, lowpri_before); // priority-1 target must not fire
+    m_initiator.do_write<uint32_t>(ALIAS_ADDR, 0x88888888UL);
+    ASSERT_EQ(alias_a_hits, a_before + 2);
+    ASSERT_EQ(alias_b_hits, b_before + 2);
+    ASSERT_EQ(lowpri_hits, lowpri_before);
+}
+
+TEST_BENCH(RegisterTestBench, test_registers_bank_extras)
+{
+    SCP_DEBUG(()) << "**************** per-element masks: flat and multidimensional APIs ****************";
+    const uint32_t full_mask = gs::gs_full_mask<uint32_t>();
+    const uint32_t low_half_mask = 0x0000FFFFUL;
+    const uint32_t high_half_mask = 0xFFFF0000UL;
+
+    ASSERT_EQ(BANK1D.get_element_mask(0), full_mask);
+    BANK1D[0] = 0xAAAAAAAAUL;
+    BANK1D[1] = 0xBBBBBBBBUL;
+    BANK1D.set_element_mask(0, low_half_mask);
+    BANK1D.set_element_mask({ 1 }, high_half_mask);
+    ASSERT_EQ(BANK1D.get_element_mask(0), low_half_mask);
+    ASSERT_EQ(BANK1D.get_element_mask({ 1 }), high_half_mask);
+    m_initiator.do_write<uint32_t>(BANK1D_ADDR, 0x55555555UL);
+    m_initiator.do_write<uint32_t>(BANK1D_ADDR + BANK1D_STRIDE, 0x66666666UL);
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[0]), 0xAAAA5555UL);
+    ASSERT_EQ(static_cast<uint32_t>(BANK1D[1]), 0x6666BBBBUL);
+    BANK1D.clear_element_mask(0);
+    BANK1D.clear_element_mask({ 1 });
+    ASSERT_EQ(BANK1D.get_element_mask(0), full_mask);
+    ASSERT_EQ(BANK1D.get_element_mask(1), full_mask);
+
+    BANK_GAP[1] = 0xAAAAAAAAUL;
+    BANK_GAP.set_element_mask(1, low_half_mask);
+    m_initiator.do_write<uint32_t>(BANK_GAP_ADDR + BANK_GAP_STRIDE, 0x55555555UL);
+    ASSERT_EQ(static_cast<uint32_t>(BANK_GAP[1]), 0xAAAA5555UL);
+    BANK_GAP.clear_element_mask(1);
+
+    BANK2D(1, 2) = 0xAAAAAAAAUL;
+    std::vector<uint64_t> bank2d_indices{ 1, 2 };
+    BANK2D.set_element_mask(bank2d_indices, low_half_mask);
+    ASSERT_EQ(BANK2D.get_element_mask({ 1, 2 }), low_half_mask);
+    const uint64_t bank2d_flat_index = 1 * BANK2D_COLS + 2;
+    ASSERT_EQ(BANK2D.get_element_mask(bank2d_flat_index), low_half_mask);
+    const uint64_t bank2d_addr = BANK2D_ADDR + BANK2D_ROW_STRIDE + 2 * BANK2D_COL_STRIDE;
+    m_initiator.do_write<uint32_t>(bank2d_addr, 0x55555555UL);
+    ASSERT_EQ(static_cast<uint32_t>(BANK2D(1, 2)), 0xAAAA5555UL);
+    BANK2D.clear_element_mask(bank2d_indices);
+    ASSERT_EQ(BANK2D.get_element_mask(bank2d_flat_index), full_mask);
+
+    SCP_DEBUG(()) << "**************** 3D banks: shape and layout constraint ****************";
+    // Sanity: both banks are 3D, 2x2x2, and share the same stride triple.
+    ASSERT_EQ(BANK3D_A.get_dims(), 3u);
+    ASSERT_EQ(BANK3D_B.get_dims(), 3u);
+    ASSERT_EQ(BANK3D_A.get_dim_count(0), BANK3D_D0);
+    ASSERT_EQ(BANK3D_A.get_dim_count(1), BANK3D_D1);
+    ASSERT_EQ(BANK3D_A.get_dim_count(2), BANK3D_D2);
+    ASSERT_EQ(BANK3D_A.get_dim_stride(0), BANK3D_S0);
+    ASSERT_EQ(BANK3D_A.get_dim_stride(1), BANK3D_S1);
+    ASSERT_EQ(BANK3D_A.get_dim_stride(2), BANK3D_S2);
+    // Span = (D0-1)*S0 + (D1-1)*S1 + (D2-1)*S2 + sizeof(elem)
+    const uint64_t bank3d_span = (BANK3D_D0 - 1) * BANK3D_S0 + (BANK3D_D1 - 1) * BANK3D_S1 +
+                                 (BANK3D_D2 - 1) * BANK3D_S2 + sizeof(uint32_t);
+    ASSERT_EQ(BANK3D_A.get_size(), bank3d_span);
+    ASSERT_EQ(BANK3D_B.get_size(), bank3d_span);
+
+    SCP_DEBUG(()) << "**************** 3D banks: address ranges overlap, element sets are disjoint ****************";
+    // Range overlap check: A ends at 0x900+0x5C=0x95C, B starts at 0x904, so
+    // 0x904..0x95C is physically shared. Element sets, however, don't collide:
+    // A element (0,0,0) occupies bytes 0x900..0x903 and B element (0,0,0)
+    // occupies bytes 0x904..0x907, and so on. reg_router's claims() rejects
+    // any address that maps to a bank's inter-element gap, so every element
+    // address belongs to exactly one bank.
+    ASSERT_LT(BANK3D_B_ADDR, BANK3D_A_ADDR + bank3d_span); // ranges overlap
+    ASSERT_LT(BANK3D_A_ADDR, BANK3D_B_ADDR + bank3d_span);
+
+    // A claims its own element addresses and rejects B's.
+    for (uint64_t i = 0; i < BANK3D_D0; i++) {
+        for (uint64_t j = 0; j < BANK3D_D1; j++) {
+            for (uint64_t k = 0; k < BANK3D_D2; k++) {
+                uint64_t a_rel = i * BANK3D_S0 + j * BANK3D_S1 + k * BANK3D_S2;
+                ASSERT_TRUE(BANK3D_A.byte_offset_is_element(a_rel));
+                // B's element offsets, expressed relative to A, sit +4 bytes off
+                // A's element positions - inside A's span but off-element for A.
+                uint64_t b_rel_via_a = a_rel + (BANK3D_B_ADDR - BANK3D_A_ADDR);
+                if (b_rel_via_a < BANK3D_A.get_size()) {
+                    ASSERT_FALSE(BANK3D_A.byte_offset_is_element(b_rel_via_a));
+                }
+                ASSERT_TRUE(BANK3D_B.byte_offset_is_element(a_rel));
+            }
+        }
+    }
+
+    SCP_DEBUG(()) << "**************** 3D banks: writes reach the correct bank, never the other ****************";
+    // Prime both banks with mutually-distinct patterns then verify each bank's
+    // read-back mirrors only its own writes.
+    for (uint64_t i = 0; i < BANK3D_D0; i++) {
+        for (uint64_t j = 0; j < BANK3D_D1; j++) {
+            for (uint64_t k = 0; k < BANK3D_D2; k++) {
+                BANK3D_A[i][j][k] = 0xAAAA0000UL | (i << 8) | (j << 4) | k;
+                BANK3D_B[i][j][k] = 0xBBBB0000UL | (i << 8) | (j << 4) | k;
+            }
+        }
+    }
+    for (uint64_t i = 0; i < BANK3D_D0; i++) {
+        for (uint64_t j = 0; j < BANK3D_D1; j++) {
+            for (uint64_t k = 0; k < BANK3D_D2; k++) {
+                uint32_t va = BANK3D_A(i, j, k);
+                uint32_t vb = BANK3D_B(i, j, k);
+                ASSERT_EQ(va, 0xAAAA0000UL | (i << 8) | (j << 4) | k);
+                ASSERT_EQ(vb, 0xBBBB0000UL | (i << 8) | (j << 4) | k);
+                // And each element sits at a physically distinct 4-byte slot in
+                // memory (A on even 4-byte boundaries within its stride mesh,
+                // B on the neighbouring odd 4-byte boundaries).
+                uint32_t mem_a = 0, mem_b = 0;
+                m_initiator.do_read<uint32_t>(BANK3D_A_ADDR + i * BANK3D_S0 + j * BANK3D_S1 + k * BANK3D_S2, mem_a);
+                m_initiator.do_read<uint32_t>(BANK3D_B_ADDR + i * BANK3D_S0 + j * BANK3D_S1 + k * BANK3D_S2, mem_b);
+                ASSERT_EQ(mem_a, 0xAAAA0000UL | (i << 8) | (j << 4) | k);
+                ASSERT_EQ(mem_b, 0xBBBB0000UL | (i << 8) | (j << 4) | k);
+            }
+        }
+    }
+
+    SCP_DEBUG(()) << "**************** 3D banks: initiator writes route to exactly one bank ****************";
+    // Write A(1,0,1): abs = 0x900 + 0x40 + 0 + 8 = 0x948. B does NOT claim 0x948
+    // (offset 0x44 into B: 0x44 % 0x40 = 0x4, 0x4 % 0x10 = 0x4, 0x4 % 8 = 0x4 >=
+    // elem_size), so only A fires.
+    int a_before = bank3d_a_hits;
+    int b_before = bank3d_b_hits;
+    uint64_t addr_A_101 = BANK3D_A_ADDR + 1 * BANK3D_S0 + 0 * BANK3D_S1 + 1 * BANK3D_S2;
+    m_initiator.do_write<uint32_t>(addr_A_101, 0xA1010101UL);
+    ASSERT_EQ(bank3d_a_hits, a_before + 1);
+    ASSERT_EQ(bank3d_b_hits, b_before); // no cross-fire onto B
+    ASSERT_EQ(bank3d_a_last_rel_addr, 1UL * BANK3D_S0 + 1UL * BANK3D_S2);
+
+    // Symmetrically, a write to B(1,0,1) hits B and not A.
+    uint64_t addr_B_101 = BANK3D_B_ADDR + 1 * BANK3D_S0 + 0 * BANK3D_S1 + 1 * BANK3D_S2;
+    m_initiator.do_write<uint32_t>(addr_B_101, 0xB1010101UL);
+    ASSERT_EQ(bank3d_a_hits, a_before + 1); // A didn't fire again
+    ASSERT_EQ(bank3d_b_hits, b_before + 1);
+    ASSERT_EQ(bank3d_b_last_rel_addr, 1UL * BANK3D_S0 + 1UL * BANK3D_S2);
+
+    // Read-back through the cursor confirms neither bank stomped on the other.
+    ASSERT_EQ(static_cast<uint32_t>(BANK3D_A(1, 0, 1)), 0xA1010101UL);
+    ASSERT_EQ(static_cast<uint32_t>(BANK3D_B(1, 0, 1)), 0xB1010101UL);
+
+    SCP_DEBUG(())
+        << "**************** 3D banks: writes in overlapping range but into the gap of the other ****************";
+    // A does NOT claim 0x904 (B's element (0,0,0) sitting in A's gap). Writing
+    // to 0x904 must land only on B, leaving A(0,0,0) untouched.
+    uint32_t a_000_before = BANK3D_A(0, 0, 0);
+    int a_before2 = bank3d_a_hits;
+    int b_before2 = bank3d_b_hits;
+    m_initiator.do_write<uint32_t>(BANK3D_B_ADDR, 0x0BEEF001UL);
+    ASSERT_EQ(bank3d_a_hits, a_before2); // A untouched
+    ASSERT_EQ(bank3d_b_hits, b_before2 + 1);
+    ASSERT_EQ(static_cast<uint32_t>(BANK3D_B(0, 0, 0)), 0x0BEEF001UL);
+    ASSERT_EQ(static_cast<uint32_t>(BANK3D_A(0, 0, 0)), a_000_before);
+
+    SCP_DEBUG(()) << "**************** Priority: LOWPRI (prio 1) is filtered out at ALIAS_ADDR ****************";
+    // At ALIAS_ADDR (=0x800), the claimants are: ALIAS_A (prio 0), ALIAS_B
+    // (prio 0), LOWPRI (prio 1). SHADOW's grid covers [0, 0x1000) too, so it
+    // is also a prio-0 claimant. reg_router keeps only the strongest priority
+    // set, so LOWPRI never fires.
+    int prio_a_before = alias_a_hits;
+    int prio_b_before = alias_b_hits;
+    int prio_low_before = lowpri_hits;
+    int prio_shadow_before = shadow_hits;
+    m_initiator.do_write<uint32_t>(ALIAS_ADDR, 0xCAFECAFEUL);
+    ASSERT_EQ(alias_a_hits, prio_a_before + 1);
+    ASSERT_EQ(alias_b_hits, prio_b_before + 1);
+    ASSERT_EQ(shadow_hits, prio_shadow_before + 1);
+    ASSERT_EQ(lowpri_hits, prio_low_before);
+    // Multiple writes confirm the filter is applied every time, not just once.
+    m_initiator.do_write<uint32_t>(ALIAS_ADDR, 0x0);
+    m_initiator.do_write<uint32_t>(ALIAS_ADDR, 0x0);
+    ASSERT_EQ(alias_a_hits, prio_a_before + 3);
+    ASSERT_EQ(alias_b_hits, prio_b_before + 3);
+    ASSERT_EQ(lowpri_hits, prio_low_before);
+
+    SCP_DEBUG(()) << "**************** SHADOW: fires alongside every other prio-0 callback ****************";
+    // SHADOW.dim_counts = {0x400}, dim_strides = {4} -> element grid covers
+    // every 4-byte-aligned address in [0, 0x1000). Same priority (0) as every
+    // other callback in the fixture, so every priority-0 access must fan out
+    // to SHADOW in addition to the specific register that owns the address.
+    ASSERT_EQ(SHADOW.get_dims(), 1u);
+    ASSERT_EQ(SHADOW.get_dim_count(0), SHADOW_LEN);
+    ASSERT_EQ(SHADOW.get_dim_stride(0), SHADOW_STRIDE);
+
+    // Baseline the counter, then hit a variety of unrelated registers and
+    // watch shadow_hits increment once per priority-0 write. Each of the
+    // targets we touch here has its own post_write callback whose assertions
+    // (defined in end_of_elaboration) depend on last_written_*/last_used_mask
+    // trackers, so we prime those before each write.
+    int sh_before = shadow_hits;
+    int bank1d_before = bank1d_post_writes;
+    int bank2d_before = bank2d_post_writes;
+
+    // CMD0: post_write asserts read-back equals last_written_value.
+    last_used_mask = gs::gs_full_mask<uint32_t>();
+    CMD0.set_mask(last_used_mask);
+    last_written_value = 0x11111111UL;
+    m_initiator.do_write<uint32_t>(CMD0_ADDR, 0x11111111UL);
+
+    // FIFO0: first post_write asserts FIFO0[last_written_idx] == last_written_value.
+    last_written_idx = 1UL;
+    FIFO0.set_mask(gs::gs_full_mask<uint32_t>());
+    last_used_mask = gs::gs_full_mask<uint32_t>();
+    last_written_value = 0x22222222UL;
+    m_initiator.do_write<uint32_t>(FIFO0_ADDR + 4UL, 0x22222222UL);
+
+    m_initiator.do_write<uint32_t>(BANK1D_ADDR, 0x33333333UL);      // hits BANK1D[0]
+    m_initiator.do_write<uint32_t>(BANK2D_ADDR + BANK2D_ROW_STRIDE, // hits BANK2D[1][0]
+                                   0x44444444UL);
+    m_initiator.do_write<uint32_t>(addr_A_101, 0x55555555UL); // hits BANK3D_A(1,0,1)
+
+    ASSERT_EQ(shadow_hits, sh_before + 5);
+    // And the corresponding "owning" register callbacks still fired for the
+    // two we track post_write on directly.
+    ASSERT_EQ(bank1d_post_writes, bank1d_before + 1);
+    ASSERT_EQ(bank2d_post_writes, bank2d_before + 1);
+
+    SCP_DEBUG(()) << "**************** SHADOW: address decoded is relative and 4-byte-indexed ****************";
+    // The last shadow write was to BANK3D_A(1,0,1) at absolute 0x948. With
+    // SHADOW at base 0, use_offset=true, the callback sees address 0x948 and
+    // decode_access maps it to element 0x948/4 = 0x252.
+    ASSERT_EQ(shadow_last_rel_addr, addr_A_101);
+    tlm::tlm_generic_payload probe;
+    probe.set_address(shadow_last_rel_addr);
+    auto sh_acc = SHADOW.decode_access(probe);
+    ASSERT_TRUE(bool(sh_acc));
+    ASSERT_EQ(sh_acc.index, shadow_last_rel_addr / SHADOW_STRIDE);
+    ASSERT_EQ(sh_acc.indices.size(), 1u);
+    ASSERT_EQ(sh_acc.indices[0], shadow_last_rel_addr / SHADOW_STRIDE);
+
+    SCP_DEBUG(()) << "**************** SHADOW: does not fire on unclaimed addresses ****************";
+    // A read at BANK_GAP_ADDR+4 lands in BANK_GAP's inter-element gap. SHADOW's
+    // grid is 4-byte stride/elem, so 0x404 is a SHADOW element and SHADOW does
+    // fire. Read that address, then read an address outside the register file
+    // (still in reg_memory) and verify SHADOW's counter for that OOR-of-shadow
+    // access does not increment beyond what it would otherwise.
+    int sh_before_oor = shadow_hits;
+    // 0x1004 is inside reg_memory but outside SHADOW's element grid (grid ends
+    // at 0x1000). Only reg_memory should service it - no callbacks fire.
+    m_initiator.do_write<uint32_t>(0x1004UL, 0x66666666UL);
+    ASSERT_EQ(shadow_hits, sh_before_oor);
+}
+
 int sc_main(int argc, char* argv[])
 {
     scp::LoggingGuard logging_guard(scp::LogConfig()
@@ -282,6 +1033,22 @@ int sc_main(int argc, char* argv[])
         { "test_registers.reg_memory.target_socket.size", cci::cci_value(REG_MEM_SZ) },
         { "test_registers.reg_memory.target_socket.relative_addresses", cci::cci_value(false) },
         { "test_registers.reg_memory.verbose", cci::cci_value(true) },
+        { "test_registers.reg_memory.init_mem", cci::cci_value(true) },
+        { "test_registers.LOWPRI.target_socket.priority", cci::cci_value(1UL) },
+
+        { "test_registers_bank.reg_memory.target_socket.address", cci::cci_value(REG_MEM_ADDR) },
+        { "test_registers_bank.reg_memory.target_socket.size", cci::cci_value(REG_MEM_SZ) },
+        { "test_registers_bank.reg_memory.target_socket.relative_addresses", cci::cci_value(false) },
+        { "test_registers_bank.reg_memory.verbose", cci::cci_value(true) },
+        { "test_registers_bank.reg_memory.init_mem", cci::cci_value(true) },
+        { "test_registers_bank.LOWPRI.target_socket.priority", cci::cci_value(1UL) },
+
+        { "test_registers_bank_extras.reg_memory.target_socket.address", cci::cci_value(REG_MEM_ADDR) },
+        { "test_registers_bank_extras.reg_memory.target_socket.size", cci::cci_value(REG_MEM_SZ) },
+        { "test_registers_bank_extras.reg_memory.target_socket.relative_addresses", cci::cci_value(false) },
+        { "test_registers_bank_extras.reg_memory.verbose", cci::cci_value(true) },
+        { "test_registers_bank_extras.reg_memory.init_mem", cci::cci_value(true) },
+        { "test_registers_bank_extras.LOWPRI.target_socket.priority", cci::cci_value(1UL) },
     });
 
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
…g register arrays

- Without a specific type to handle register arrays, the only way to define them for now is either using a single gs_register<T> with size = the array size if the registers are contiguous with stride = the sizeof(T), but in case of non-contiguous allocation of the registers inside the array, there was no efficient way of doing that. So, a vector of gs_register<T> for 1D registers was used, or vecotr<vecotr<gs_register<T>>> for 2D array and so on. With the introduction of the template specialization gs::gs_register<gs::gs_bank_of<T>> only one gs_register is used to represent n dimensional array of registers which reduces the number of gs_registers and the number of bound sockets dramataically, hence increase the performance of the simulation.
- Handle the pre/post read/write callbacks of the gs::gs_register<gs::gs_bank_of<T>> as if it is a single gs_register<T> callback with APIs to get the indices of the accessed bank element.
- Handle the same semantics for arithmatic and logic operations between the gs::gs_register<gs::gs_bank_of<T>> individual elements and integral types and also with single gs_register<T>. So, operations like REG_BANK[1][2] += 5; are possible.
- Handle the filed access operation so REG_BANK[0][1][FIELD_A] is also possible.
- Add new test cases to tests/components/gs_register to test the gs::gs_register<gs::gs_bank_of<T>> callbacks and different possible operations.