### PR TITLE
Add ARM target for PDP Cortex-M7 bring-up

### DIFF
--- a/qemu-components/common/include/libqemu-cxx/target_info.h
+++ b/qemu-components/common/include/libqemu-cxx/target_info.h
@@ -12,6 +12,7 @@ namespace qemu {
 
 enum Target {
     AARCH64,
+    ARM,
     RISCV64,
     RISCV32,
     MICROBLAZE,

--- a/qemu-components/common/include/qemu-instance.h
+++ b/qemu-components/common/include/qemu-instance.h
@@ -292,6 +292,8 @@ protected:
     {
         if (s == "AARCH64") {
             return QemuInstance::Target::AARCH64;
+        } else if (s == "ARM") {
+            return QemuInstance::Target::ARM;
         } else if (s == "RISCV64") {
             return QemuInstance::Target::RISCV64;
         } else if (s == "RISCV32") {

--- a/qemu-components/common/src/libqemu-cxx/target-info.cc
+++ b/qemu-components/common/src/libqemu-cxx/target-info.cc
@@ -16,6 +16,9 @@ const char* get_target_name(Target t)
     case AARCH64:
         return "AArch64";
 
+    case ARM:
+        return "ARM (32-bit)";
+
     case RISCV64:
         return "RISC-V (64 bits)";
 
@@ -38,6 +41,10 @@ const char* get_target_name(Target t)
 
 #ifndef LIBQEMU_TARGET_aarch64_LIBRARY
 #define LIBQEMU_TARGET_aarch64_LIBRARY nullptr
+#endif
+
+#ifndef LIBQEMU_TARGET_arm_LIBRARY
+#define LIBQEMU_TARGET_arm_LIBRARY nullptr
 #endif
 
 #ifndef LIBQEMU_TARGET_riscv64_LIBRARY
@@ -65,6 +72,9 @@ const char* get_target_lib(Target t)
     switch (t) {
     case AARCH64:
         return LIBQEMU_TARGET_aarch64_LIBRARY;
+
+    case ARM:
+        return LIBQEMU_TARGET_arm_LIBRARY;
 
     case RISCV64:
         return LIBQEMU_TARGET_riscv64_LIBRARY;


### PR DESCRIPTION
Add ARM as a target alongside aarch64 for Cortex-M7. Counterpart to the libqemu-side arm build-target enablement; needed so qbox can select and load a 32-bit ARM QemuInstance for PDP Cortex-M7 bring-up.