### PR TITLE
systemc-components/addrtr: fix an issue in the map_dmi_start_end_addr…

### DIFF
--- a/systemc-components/addrtr/include/addrtr.h
+++ b/systemc-components/addrtr/include/addrtr.h
@@ -79,11 +79,12 @@ private:
                           << " size: 0x" << std::hex << m_mapping_size;
         }
         if (end_addr >= (p_mapped_base_addr.get_value() + m_mapping_size)) {
-            end_addr = m_base_addr + m_mapping_size;
-        } else if ((end_addr > start_addr) && (end_addr < (p_mapped_base_addr.get_value() + m_mapping_size))) {
+            end_addr = m_base_addr + m_mapping_size - 1;
+        } else if ((end_addr >= p_mapped_base_addr.get_value()) &&
+                   (end_addr < (p_mapped_base_addr.get_value() + m_mapping_size))) {
             end_addr = addr_bw(end_addr);
         } else {
-            SCP_FATAL(()) << "DMI granted end address 0x" << std::hex << start_addr
+            SCP_FATAL(()) << "DMI granted end address 0x" << std::hex << end_addr
                           << " is smaller than the mapped area 0x" << std::hex << p_mapped_base_addr.get_value()
                           << " size: 0x" << std::hex << m_mapping_size;
         }

--- a/tests/components/addrtr/addrtr-bench.h
+++ b/tests/components/addrtr/addrtr-bench.h
@@ -22,13 +22,17 @@ class AddrtrTestBench : public TestBench
 {
 public:
     static constexpr size_t TARGET_MMIO_SIZE = 1024;
+    static constexpr uint64_t TARGET_BASE_ADDR = 0x1000;
+    static constexpr uint64_t MAPPED_BASE_ADDR = 0x110;
+    static constexpr uint64_t DMI_RANGE_OFFSET = 0x20;
+    static constexpr uint64_t DMI_RANGE_SIZE = 0x100;
 
     class TargetTesterDMIinv : public TargetTester
     {
         using TargetTester::TargetTester;
 
     public:
-        void do_dmi_invalidate(uint64_t addr) { socket->invalidate_direct_mem_ptr(addr, addr + TARGET_MMIO_SIZE); }
+        void do_dmi_invalidate(uint64_t start, uint64_t end) { socket->invalidate_direct_mem_ptr(start, end); }
     };
 
 public:
@@ -42,26 +46,32 @@ private:
     InitiatorTester m_initiator;
     TargetTesterDMIinv m_target;
 
-    uint64_t sent_addr;
-    uint64_t offset = 0xDEADULL;
+    uint64_t sent_addr = 0;
+    bool return_dmi_range = false;
+    uint64_t dmi_range_size = 0;
+
+    uint64_t mapped_addr() const { return MAPPED_BASE_ADDR + (sent_addr - TARGET_BASE_ADDR); }
 
     /* Initiator callback */
     void invalidate_direct_mem_ptr(uint64_t start_range, uint64_t end_range)
     {
-        EXPECT_EQ(start_range, sent_addr);
-        EXPECT_EQ(end_range, sent_addr + TARGET_MMIO_SIZE);
+        EXPECT_EQ(start_range, TARGET_BASE_ADDR);
+        EXPECT_EQ(end_range, TARGET_BASE_ADDR + TARGET_MMIO_SIZE - 1);
     }
 
     /* Target callbacks */
     TlmResponseStatus target_access(uint64_t addr, uint8_t* data, size_t len)
     {
-        EXPECT_EQ(sent_addr + offset, addr);
+        EXPECT_EQ(mapped_addr(), addr);
         return tlm::TLM_OK_RESPONSE;
     }
 
     bool get_direct_mem_ptr(uint64_t addr, TlmDmi& dmi_data)
     {
-        EXPECT_EQ(addr, sent_addr + offset);
+        EXPECT_EQ(addr, mapped_addr());
+        dmi_data.allow_read_write();
+        dmi_data.set_start_address(addr);
+        dmi_data.set_end_address(return_dmi_range ? addr + dmi_range_size - 1 : addr);
         return true;
     }
 
@@ -80,11 +90,25 @@ protected:
 
     void do_dmi(uint64_t addr)
     {
-        uint64_t data = 0x42ULL;
-        TlmGenericPayload txn;
         sent_addr = addr;
-        m_initiator.do_dmi_request(addr);
-        m_target.do_dmi_invalidate(addr + offset);
+        return_dmi_range = false;
+        dmi_range_size = 0;
+        ASSERT_TRUE(m_initiator.do_dmi_request(addr));
+        const auto& dmi = m_initiator.get_last_dmi_data();
+        ASSERT_EQ(dmi.get_start_address(), sent_addr);
+        ASSERT_EQ(dmi.get_end_address(), sent_addr);
+        m_target.do_dmi_invalidate(MAPPED_BASE_ADDR, MAPPED_BASE_ADDR + TARGET_MMIO_SIZE - 1);
+    }
+
+    void do_dmi_with_range(uint64_t addr, uint64_t range_size)
+    {
+        sent_addr = addr;
+        return_dmi_range = true;
+        dmi_range_size = range_size;
+        ASSERT_TRUE(m_initiator.do_dmi_request(addr));
+        const auto& dmi = m_initiator.get_last_dmi_data();
+        ASSERT_EQ(dmi.get_start_address(), sent_addr);
+        ASSERT_EQ(dmi.get_end_address(), sent_addr + range_size - 1);
     }
 
 public:
@@ -95,8 +119,6 @@ public:
         , m_target("target-tester", TARGET_MMIO_SIZE)
     {
         using namespace std::placeholders;
-
-        offset = 0x10ULL;
 
         m_initiator.register_invalidate_direct_mem_ptr(
             std::bind(&AddrtrTestBench::invalidate_direct_mem_ptr, this, _1, _2));

--- a/tests/components/addrtr/addrtr-tests.cc
+++ b/tests/components/addrtr/addrtr-tests.cc
@@ -16,18 +16,32 @@
  */
 TEST_BENCH(AddrtrTestBench, Tester)
 {
-    do_txn(0x100ULL, 0);
-    do_txn(0x100ULL, 1);
-    do_dmi(0x100ULL);
+    do_txn(TARGET_BASE_ADDR, 0);
+    do_txn(TARGET_BASE_ADDR, 1);
+    do_dmi(TARGET_BASE_ADDR);
 }
+
+TEST_BENCH(AddrtrTestBench, DmiRange)
+{
+    const auto addr = TARGET_BASE_ADDR + AddrtrTestBench::DMI_RANGE_OFFSET;
+    do_dmi_with_range(addr, AddrtrTestBench::DMI_RANGE_SIZE);
+}
+
+TEST_BENCH(AddrtrTestBench, DmiBoundary) { do_dmi_with_range(TARGET_BASE_ADDR, AddrtrTestBench::TARGET_MMIO_SIZE); }
 
 int sc_main(int argc, char* argv[])
 {
     gs::ConfigurableBroker m_broker({
         { "log_level", cci::cci_value(5) },
-        { "Tester.exclusive_addrtr.target_socket.address", cci::cci_value(0x100ULL) },
+        { "Tester.exclusive_addrtr.target_socket.address", cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
         { "Tester.exclusive_addrtr.target_socket.size", cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
-        { "Tester.exclusive_addrtr.mapped_base_addr", cci::cci_value(0x110ULL) },
+        { "Tester.exclusive_addrtr.mapped_base_addr", cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "DmiRange.exclusive_addrtr.target_socket.address", cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "DmiRange.exclusive_addrtr.target_socket.size", cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "DmiRange.exclusive_addrtr.mapped_base_addr", cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "DmiBoundary.exclusive_addrtr.target_socket.address", cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "DmiBoundary.exclusive_addrtr.target_socket.size", cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "DmiBoundary.exclusive_addrtr.mapped_base_addr", cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
     });
 
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
… function

- The end_addr in the function map_dmi_start_end_addr() which is used to transform the get_direct_mem_ptr was checked wrongly against the modified start_addr, check it correctly against p_mapped_base_addr.
- Modify the test bench to accomodate the change.