### PR TITLE
libqemu: Switch to version libqemu-v11.0-v0.13

### DIFF
--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -27,7 +27,7 @@ CPMDeclarePackage(SCP
 CPMDeclarePackage(qemu
     NAME libqemu
     GIT_REPOSITORY ${LIBQEMU_GIT}
-    GIT_TAG libqemu-v11.0-v0.12
+    GIT_TAG libqemu-v11.0-v0.13
     GIT_SUBMODULES CMakeLists.txt
     GIT_SHALLOW ON
 )


### PR DESCRIPTION
Changelog:

- ui/sdl2: avoid unsupported external EGL handoff
- hvf: gate SME2 registers on guest SME support
- fix: locate VNC keymaps in build-tree LibQemu
- hexagon: tests: don't use coproc on tests that don't need it
- ci: add hexagon functional-test jobs
- tests/functional/qemu_test/asset.py: Don't use setxattr when it doesn't exist
- ci: remove legacy quic-gitlab-ci.d/
- quic/install-deps.sh: add libslirp-dev

Signed-off-by: Jerome Haxhiaj <jhaxhiaj@qti.qualcomm.com>
