### PR TITLE
systemc-components/addrtr: Fix addrtr DMI pointer mapping issue

### DIFF
--- a/systemc-components/addrtr/include/addrtr.h
+++ b/systemc-components/addrtr/include/addrtr.h
@@ -7,7 +7,9 @@
 #ifndef _GREENSOCS_BASE_COMPONENTS_ADDRTR_H
 #define _GREENSOCS_BASE_COMPONENTS_ADDRTR_H
 
+#include <algorithm>
 #include <cinttypes>
+#include <limits>
 #include <vector>
 
 #include <systemc>
@@ -38,6 +40,40 @@ class addrtr : public sc_core::sc_module
 private:
     SCP_LOGGER();
 
+    bool range_end(sc_dt::uint64 start, sc_dt::uint64 size, sc_dt::uint64& end) const
+    {
+        if (size == 0 || start > std::numeric_limits<sc_dt::uint64>::max() - (size - 1)) {
+            return false;
+        }
+        end = start + size - 1;
+        return true;
+    }
+
+    bool map_window(sc_dt::uint64& start_addr, sc_dt::uint64& end_addr, unsigned char** dmi_ptr = nullptr)
+    {
+        sc_dt::uint64 mapped_end;
+        sc_dt::uint64 target_end;
+        const sc_dt::uint64 mapped_start = p_mapped_base_addr.get_value();
+        const sc_dt::uint64 target_start = m_base_addr;
+
+        if (!range_end(mapped_start, m_mapping_size, mapped_end) ||
+            !range_end(target_start, m_mapping_size, target_end) || end_addr < start_addr || end_addr < mapped_start ||
+            start_addr > mapped_end) {
+            return false;
+        }
+
+        const sc_dt::uint64 clipped_start = std::max(start_addr, mapped_start);
+        const sc_dt::uint64 clipped_end = std::min(end_addr, mapped_end);
+
+        if (dmi_ptr != nullptr && *dmi_ptr != nullptr) {
+            *dmi_ptr += clipped_start - start_addr;
+        }
+
+        start_addr = target_start + (clipped_start - mapped_start);
+        end_addr = target_start + (clipped_end - mapped_start);
+        return true;
+    }
+
     sc_dt::uint64 addr_fw(sc_dt::uint64 addr)
     {
         auto offset = addr - m_base_addr;
@@ -50,12 +86,18 @@ private:
         return m_base_addr + offset;
     }
 
-    uint64_t map_txn_addr(tlm::tlm_generic_payload& trans)
+    sc_dt::uint64 map_txn_addr(tlm::tlm_generic_payload& trans)
     {
-        uint64_t addr = trans.get_address();
-        uint64_t len = trans.get_data_length();
-        uint64_t mapped_addr = addr;
-        if ((addr >= m_base_addr) && ((addr + len - 1) < (m_base_addr + m_mapping_size))) {
+        sc_dt::uint64 addr = trans.get_address();
+        sc_dt::uint64 len = trans.get_data_length();
+        sc_dt::uint64 mapped_addr = addr;
+        sc_dt::uint64 target_end;
+        sc_dt::uint64 mapped_end;
+        sc_dt::uint64 txn_end = addr;
+        const bool range_valid = range_end(m_base_addr, m_mapping_size, target_end);
+        const bool mapped_range_valid = range_end(p_mapped_base_addr.get_value(), m_mapping_size, mapped_end);
+        const bool txn_valid = (len == 0) || range_end(addr, len, txn_end);
+        if (range_valid && mapped_range_valid && txn_valid && addr >= m_base_addr && txn_end <= target_end) {
             mapped_addr = addr_fw(addr);
             trans.set_address(mapped_addr);
         } else {
@@ -66,34 +108,10 @@ private:
         return mapped_addr;
     }
 
-    void map_dmi_start_end_addr(uint64_t& start_addr, uint64_t& end_addr)
-    {
-        if (start_addr < p_mapped_base_addr.get_value()) {
-            start_addr = m_base_addr;
-        } else if ((start_addr >= p_mapped_base_addr.get_value()) &&
-                   (start_addr < (p_mapped_base_addr.get_value() + m_mapping_size))) {
-            start_addr = addr_bw(start_addr);
-        } else {
-            SCP_FATAL(()) << "DMI granted start address 0x" << std::hex << start_addr
-                          << " is bigger than the mapped area 0x" << std::hex << p_mapped_base_addr.get_value()
-                          << " size: 0x" << std::hex << m_mapping_size;
-        }
-        if (end_addr >= (p_mapped_base_addr.get_value() + m_mapping_size)) {
-            end_addr = m_base_addr + m_mapping_size - 1;
-        } else if ((end_addr >= p_mapped_base_addr.get_value()) &&
-                   (end_addr < (p_mapped_base_addr.get_value() + m_mapping_size))) {
-            end_addr = addr_bw(end_addr);
-        } else {
-            SCP_FATAL(()) << "DMI granted end address 0x" << std::hex << end_addr
-                          << " is smaller than the mapped area 0x" << std::hex << p_mapped_base_addr.get_value()
-                          << " size: 0x" << std::hex << m_mapping_size;
-        }
-    }
-
     void b_transport(tlm::tlm_generic_payload& trans, sc_core::sc_time& delay)
     {
-        uint64_t orig_addr = trans.get_address();
-        uint64_t mapped_addr = map_txn_addr(trans);
+        sc_dt::uint64 orig_addr = trans.get_address();
+        sc_dt::uint64 mapped_addr = map_txn_addr(trans);
         SCP_DEBUG(()) << "b_transport to addr: 0x" << std::hex << orig_addr << " will be mapped to addr: 0x" << std::hex
                       << mapped_addr;
         initiator_socket->b_transport(trans, delay);
@@ -102,8 +120,8 @@ private:
 
     unsigned int transport_dbg(tlm::tlm_generic_payload& trans)
     {
-        uint64_t orig_addr = trans.get_address();
-        uint64_t mapped_addr = map_txn_addr(trans);
+        sc_dt::uint64 orig_addr = trans.get_address();
+        sc_dt::uint64 mapped_addr = map_txn_addr(trans);
         SCP_DEBUG(()) << "transport_dbg to addr: 0x" << std::hex << orig_addr << " will be mapped to addr: 0x"
                       << std::hex << mapped_addr;
         unsigned int ret = initiator_socket->transport_dbg(trans);
@@ -113,14 +131,26 @@ private:
 
     bool get_direct_mem_ptr(tlm::tlm_generic_payload& trans, tlm::tlm_dmi& dmi_data)
     {
-        uint64_t orig_addr = trans.get_address();
-        uint64_t mapped_addr = map_txn_addr(trans);
+        sc_dt::uint64 orig_addr = trans.get_address();
+        sc_dt::uint64 mapped_addr = map_txn_addr(trans);
         bool ret = initiator_socket->get_direct_mem_ptr(trans, dmi_data);
         trans.set_address(orig_addr);
         if (ret) {
-            uint64_t start_addr = dmi_data.get_start_address();
-            uint64_t end_addr = dmi_data.get_end_address();
-            map_dmi_start_end_addr(start_addr, end_addr);
+            sc_dt::uint64 start_addr = dmi_data.get_start_address();
+            sc_dt::uint64 end_addr = dmi_data.get_end_address();
+            unsigned char* dmi_ptr = dmi_data.get_dmi_ptr();
+
+            if (mapped_addr < start_addr || mapped_addr > end_addr) {
+                SCP_DEBUG(()) << "DMI grant did not contain requested mapped address 0x" << std::hex << mapped_addr;
+                return false;
+            }
+
+            ret = map_window(start_addr, end_addr, &dmi_ptr);
+            if (!ret) {
+                SCP_DEBUG(()) << "DMI grant did not overlap mapped range";
+                return false;
+            }
+            dmi_data.set_dmi_ptr(dmi_ptr);
             dmi_data.set_start_address(start_addr);
             dmi_data.set_end_address(end_addr);
             SCP_DEBUG(()) << "DMI was granted to range 0x" << std::hex << start_addr << " - 0x" << std::hex << end_addr;
@@ -130,9 +160,13 @@ private:
 
     void invalidate_direct_mem_ptr(sc_dt::uint64 start, sc_dt::uint64 end)
     {
-        uint64_t start_addr = start;
-        uint64_t end_addr = end;
-        map_dmi_start_end_addr(start_addr, end_addr);
+        sc_dt::uint64 start_addr = start;
+        sc_dt::uint64 end_addr = end;
+        if (!map_window(start_addr, end_addr)) {
+            SCP_DEBUG(()) << "Ignoring invalidate_direct_mem_ptr outside mapped range 0x" << std::hex << start
+                          << " - 0x" << std::hex << end;
+            return;
+        }
         SCP_DEBUG(()) << "invalidate_direct_mem_ptr request to range 0x" << std::hex << start_addr << " - 0x"
                       << std::hex << end_addr;
         target_socket->invalidate_direct_mem_ptr(start_addr, end_addr);

--- a/tests/components/addrtr/addrtr-bench.h
+++ b/tests/components/addrtr/addrtr-bench.h
@@ -8,6 +8,8 @@
 #define _BASE_COMPONENTS_TESTS_ADDRTR_TEST_BENCH_H
 
 #include <functional>
+#include <array>
+#include <optional>
 
 #include <systemc>
 #include <tlm>
@@ -26,6 +28,9 @@ public:
     static constexpr uint64_t MAPPED_BASE_ADDR = 0x110;
     static constexpr uint64_t DMI_RANGE_OFFSET = 0x20;
     static constexpr uint64_t DMI_RANGE_SIZE = 0x100;
+    static constexpr uint64_t TARGET_END_ADDR = TARGET_BASE_ADDR + TARGET_MMIO_SIZE - 1;
+    static constexpr uint64_t MAPPED_END_ADDR = MAPPED_BASE_ADDR + TARGET_MMIO_SIZE - 1;
+    static constexpr uint64_t DOWNSTREAM_TESTER_SIZE = MAPPED_BASE_ADDR + TARGET_MMIO_SIZE + 16;
 
     class TargetTesterDMIinv : public TargetTester
     {
@@ -48,15 +53,26 @@ private:
 
     uint64_t sent_addr = 0;
     bool return_dmi_range = false;
+    bool return_dmi_from_zero = false;
+    bool dmi_return_value = true;
+    bool use_explicit_dmi_range = false;
     uint64_t dmi_range_size = 0;
+    uint64_t explicit_dmi_start = 0;
+    uint64_t explicit_dmi_end = 0;
+    uint64_t explicit_dmi_ptr_offset = 0;
+    std::array<unsigned char, MAPPED_BASE_ADDR + TARGET_MMIO_SIZE> dmi_memory{};
+    std::optional<std::pair<uint64_t, uint64_t>> expected_invalidation;
+    unsigned int invalidation_count = 0;
 
     uint64_t mapped_addr() const { return MAPPED_BASE_ADDR + (sent_addr - TARGET_BASE_ADDR); }
 
     /* Initiator callback */
     void invalidate_direct_mem_ptr(uint64_t start_range, uint64_t end_range)
     {
-        EXPECT_EQ(start_range, TARGET_BASE_ADDR);
-        EXPECT_EQ(end_range, TARGET_BASE_ADDR + TARGET_MMIO_SIZE - 1);
+        invalidation_count++;
+        ASSERT_TRUE(expected_invalidation.has_value());
+        EXPECT_EQ(start_range, expected_invalidation->first);
+        EXPECT_EQ(end_range, expected_invalidation->second);
     }
 
     /* Target callbacks */
@@ -69,9 +85,22 @@ private:
     bool get_direct_mem_ptr(uint64_t addr, TlmDmi& dmi_data)
     {
         EXPECT_EQ(addr, mapped_addr());
+        if (!dmi_return_value) {
+            return false;
+        }
         dmi_data.allow_read_write();
-        dmi_data.set_start_address(addr);
-        dmi_data.set_end_address(return_dmi_range ? addr + dmi_range_size - 1 : addr);
+        if (use_explicit_dmi_range) {
+            dmi_data.set_dmi_ptr(dmi_memory.data() + explicit_dmi_ptr_offset);
+            dmi_data.set_start_address(explicit_dmi_start);
+            dmi_data.set_end_address(explicit_dmi_end);
+        } else if (return_dmi_from_zero) {
+            dmi_data.set_dmi_ptr(dmi_memory.data());
+            dmi_data.set_start_address(0);
+            dmi_data.set_end_address(MAPPED_END_ADDR);
+        } else {
+            dmi_data.set_start_address(addr);
+            dmi_data.set_end_address(return_dmi_range ? addr + dmi_range_size - 1 : addr);
+        }
         return true;
     }
 
@@ -81,6 +110,7 @@ protected:
         uint64_t data = 0x42ULL;
         TlmGenericPayload txn;
         sent_addr = addr;
+        dmi_return_value = true;
         if (!dbg) {
             ASSERT_EQ(tlm::TLM_OK_RESPONSE, m_initiator.do_write(addr, data, dbg));
         } else {
@@ -88,22 +118,43 @@ protected:
         }
     }
 
+    void do_txn_with_len(uint64_t addr, size_t len)
+    {
+        std::array<uint8_t, 16> data{};
+        TlmGenericPayload txn;
+
+        ASSERT_LE(len, data.size());
+        sent_addr = addr;
+        dmi_return_value = true;
+        ASSERT_EQ(tlm::TLM_OK_RESPONSE, m_initiator.do_write_with_txn_and_ptr(txn, addr, data.data(), len));
+        EXPECT_EQ(txn.get_address(), addr);
+    }
+
     void do_dmi(uint64_t addr)
     {
         sent_addr = addr;
+        dmi_return_value = true;
+        use_explicit_dmi_range = false;
         return_dmi_range = false;
+        return_dmi_from_zero = false;
         dmi_range_size = 0;
         ASSERT_TRUE(m_initiator.do_dmi_request(addr));
         const auto& dmi = m_initiator.get_last_dmi_data();
         ASSERT_EQ(dmi.get_start_address(), sent_addr);
         ASSERT_EQ(dmi.get_end_address(), sent_addr);
-        m_target.do_dmi_invalidate(MAPPED_BASE_ADDR, MAPPED_BASE_ADDR + TARGET_MMIO_SIZE - 1);
+        expected_invalidation = std::make_pair(TARGET_BASE_ADDR, TARGET_END_ADDR);
+        invalidation_count = 0;
+        m_target.do_dmi_invalidate(MAPPED_BASE_ADDR, MAPPED_END_ADDR);
+        EXPECT_EQ(invalidation_count, 1u);
     }
 
     void do_dmi_with_range(uint64_t addr, uint64_t range_size)
     {
         sent_addr = addr;
+        dmi_return_value = true;
+        use_explicit_dmi_range = false;
         return_dmi_range = true;
+        return_dmi_from_zero = false;
         dmi_range_size = range_size;
         ASSERT_TRUE(m_initiator.do_dmi_request(addr));
         const auto& dmi = m_initiator.get_last_dmi_data();
@@ -111,12 +162,87 @@ protected:
         ASSERT_EQ(dmi.get_end_address(), sent_addr + range_size - 1);
     }
 
+    void do_dmi_with_clipped_downstream_start()
+    {
+        sent_addr = TARGET_BASE_ADDR;
+        dmi_return_value = true;
+        use_explicit_dmi_range = false;
+        return_dmi_range = false;
+        return_dmi_from_zero = true;
+        ASSERT_TRUE(m_initiator.do_dmi_request(sent_addr));
+        const auto& dmi = m_initiator.get_last_dmi_data();
+        ASSERT_EQ(dmi.get_start_address(), TARGET_BASE_ADDR);
+        ASSERT_EQ(dmi.get_end_address(), TARGET_END_ADDR);
+        ASSERT_EQ(dmi.get_dmi_ptr(), dmi_memory.data() + MAPPED_BASE_ADDR);
+    }
+
+    void do_dmi_with_explicit_range(uint64_t addr, uint64_t downstream_start, uint64_t downstream_end,
+                                    uint64_t ptr_offset, uint64_t expected_start, uint64_t expected_end,
+                                    uint64_t expected_ptr_offset)
+    {
+        sent_addr = addr;
+        dmi_return_value = true;
+        use_explicit_dmi_range = true;
+        return_dmi_range = false;
+        return_dmi_from_zero = false;
+        explicit_dmi_start = downstream_start;
+        explicit_dmi_end = downstream_end;
+        explicit_dmi_ptr_offset = ptr_offset;
+
+        ASSERT_TRUE(m_initiator.do_dmi_request(addr));
+        const auto& dmi = m_initiator.get_last_dmi_data();
+        ASSERT_EQ(dmi.get_start_address(), expected_start);
+        ASSERT_EQ(dmi.get_end_address(), expected_end);
+        ASSERT_EQ(dmi.get_dmi_ptr(), dmi_memory.data() + expected_ptr_offset);
+    }
+
+    void do_dmi_denied(uint64_t addr)
+    {
+        sent_addr = addr;
+        dmi_return_value = false;
+        use_explicit_dmi_range = false;
+        return_dmi_range = false;
+        return_dmi_from_zero = false;
+        ASSERT_FALSE(m_initiator.do_dmi_request(addr));
+    }
+
+    void do_dmi_non_overlapping_grant_returns_false(uint64_t addr, uint64_t downstream_start, uint64_t downstream_end)
+    {
+        sent_addr = addr;
+        dmi_return_value = true;
+        use_explicit_dmi_range = true;
+        return_dmi_range = false;
+        return_dmi_from_zero = false;
+        explicit_dmi_start = downstream_start;
+        explicit_dmi_end = downstream_end;
+        explicit_dmi_ptr_offset = 0;
+        ASSERT_FALSE(m_initiator.do_dmi_request(addr));
+    }
+
+    void do_invalidate(uint64_t downstream_start, uint64_t downstream_end, uint64_t expected_start,
+                       uint64_t expected_end)
+    {
+        expected_invalidation = std::make_pair(expected_start, expected_end);
+        invalidation_count = 0;
+        m_target.do_dmi_invalidate(downstream_start, downstream_end);
+        EXPECT_EQ(invalidation_count, 1u);
+        expected_invalidation.reset();
+    }
+
+    void do_non_overlapping_invalidate(uint64_t downstream_start, uint64_t downstream_end)
+    {
+        expected_invalidation.reset();
+        invalidation_count = 0;
+        m_target.do_dmi_invalidate(downstream_start, downstream_end);
+        EXPECT_EQ(invalidation_count, 0u);
+    }
+
 public:
     AddrtrTestBench(const sc_core::sc_module_name& n)
         : TestBench(n)
         , m_addrtr("exclusive_addrtr")
         , m_initiator("initiator-tester")
-        , m_target("target-tester", TARGET_MMIO_SIZE)
+        , m_target("target-tester", DOWNSTREAM_TESTER_SIZE)
     {
         using namespace std::placeholders;
 

--- a/tests/components/addrtr/addrtr-tests.cc
+++ b/tests/components/addrtr/addrtr-tests.cc
@@ -29,6 +29,63 @@ TEST_BENCH(AddrtrTestBench, DmiRange)
 
 TEST_BENCH(AddrtrTestBench, DmiBoundary) { do_dmi_with_range(TARGET_BASE_ADDR, AddrtrTestBench::TARGET_MMIO_SIZE); }
 
+TEST_BENCH(AddrtrTestBench, DmiClippedStartPointer) { do_dmi_with_clipped_downstream_start(); }
+
+TEST_BENCH(AddrtrTestBench, LastByteTransaction) { do_txn_with_len(TARGET_END_ADDR, 1); }
+
+TEST_BENCH(AddrtrTestBench, MultiByteTransactionAtEnd) { do_txn_with_len(TARGET_END_ADDR - 3, 4); }
+
+TEST_BENCH(AddrtrTestBench, ZeroLengthTransactionAtEnd) { do_txn_with_len(TARGET_END_ADDR, 0); }
+
+TEST_BENCH(AddrtrTestBench, DmiClippedEnd)
+{
+    do_dmi_with_explicit_range(TARGET_BASE_ADDR + DMI_RANGE_OFFSET, MAPPED_BASE_ADDR + DMI_RANGE_OFFSET,
+                               MAPPED_END_ADDR + 0x40, MAPPED_BASE_ADDR + DMI_RANGE_OFFSET,
+                               TARGET_BASE_ADDR + DMI_RANGE_OFFSET, TARGET_END_ADDR,
+                               MAPPED_BASE_ADDR + DMI_RANGE_OFFSET);
+}
+
+TEST_BENCH(AddrtrTestBench, DmiClippedBothEnds)
+{
+    do_dmi_with_explicit_range(TARGET_BASE_ADDR + DMI_RANGE_OFFSET, 0, MAPPED_END_ADDR + 0x40, 0, TARGET_BASE_ADDR,
+                               TARGET_END_ADDR, MAPPED_BASE_ADDR);
+}
+
+TEST_BENCH(AddrtrTestBench, DmiDeniedPropagates) { do_dmi_denied(TARGET_BASE_ADDR + DMI_RANGE_OFFSET); }
+
+TEST_BENCH(AddrtrTestBench, DmiNonOverlappingGrantReturnsFalse)
+{
+    do_dmi_non_overlapping_grant_returns_false(TARGET_BASE_ADDR + DMI_RANGE_OFFSET, MAPPED_END_ADDR + 1,
+                                               MAPPED_END_ADDR + 0x100);
+}
+
+TEST_BENCH(AddrtrTestBench, DmiGrantMustContainRequestedAddress)
+{
+    do_dmi_non_overlapping_grant_returns_false(TARGET_BASE_ADDR + DMI_RANGE_OFFSET, MAPPED_BASE_ADDR + 0x80,
+                                               MAPPED_BASE_ADDR + 0x90);
+}
+
+TEST_BENCH(AddrtrTestBench, InvalidateClippedStart)
+{
+    do_invalidate(0, MAPPED_BASE_ADDR + DMI_RANGE_OFFSET, TARGET_BASE_ADDR, TARGET_BASE_ADDR + DMI_RANGE_OFFSET);
+}
+
+TEST_BENCH(AddrtrTestBench, InvalidateClippedEnd)
+{
+    do_invalidate(MAPPED_BASE_ADDR + DMI_RANGE_OFFSET, MAPPED_END_ADDR + 0x100, TARGET_BASE_ADDR + DMI_RANGE_OFFSET,
+                  TARGET_END_ADDR);
+}
+
+TEST_BENCH(AddrtrTestBench, InvalidateNonOverlappingLowIgnored)
+{
+    do_non_overlapping_invalidate(0, MAPPED_BASE_ADDR - 1);
+}
+
+TEST_BENCH(AddrtrTestBench, InvalidateNonOverlappingHighIgnored)
+{
+    do_non_overlapping_invalidate(MAPPED_END_ADDR + 1, MAPPED_END_ADDR + 0x100);
+}
+
 int sc_main(int argc, char* argv[])
 {
     gs::ConfigurableBroker m_broker({
@@ -42,6 +99,76 @@ int sc_main(int argc, char* argv[])
         { "DmiBoundary.exclusive_addrtr.target_socket.address", cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
         { "DmiBoundary.exclusive_addrtr.target_socket.size", cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
         { "DmiBoundary.exclusive_addrtr.mapped_base_addr", cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "DmiClippedStartPointer.exclusive_addrtr.target_socket.address",
+          cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "DmiClippedStartPointer.exclusive_addrtr.target_socket.size",
+          cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "DmiClippedStartPointer.exclusive_addrtr.mapped_base_addr",
+          cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "LastByteTransaction.exclusive_addrtr.target_socket.address",
+          cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "LastByteTransaction.exclusive_addrtr.target_socket.size",
+          cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "LastByteTransaction.exclusive_addrtr.mapped_base_addr", cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "MultiByteTransactionAtEnd.exclusive_addrtr.target_socket.address",
+          cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "MultiByteTransactionAtEnd.exclusive_addrtr.target_socket.size",
+          cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "MultiByteTransactionAtEnd.exclusive_addrtr.mapped_base_addr",
+          cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "ZeroLengthTransactionAtEnd.exclusive_addrtr.target_socket.address",
+          cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "ZeroLengthTransactionAtEnd.exclusive_addrtr.target_socket.size",
+          cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "ZeroLengthTransactionAtEnd.exclusive_addrtr.mapped_base_addr",
+          cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "DmiClippedEnd.exclusive_addrtr.target_socket.address", cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "DmiClippedEnd.exclusive_addrtr.target_socket.size", cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "DmiClippedEnd.exclusive_addrtr.mapped_base_addr", cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "DmiClippedBothEnds.exclusive_addrtr.target_socket.address",
+          cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "DmiClippedBothEnds.exclusive_addrtr.target_socket.size", cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "DmiClippedBothEnds.exclusive_addrtr.mapped_base_addr", cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "DmiDeniedPropagates.exclusive_addrtr.target_socket.address",
+          cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "DmiDeniedPropagates.exclusive_addrtr.target_socket.size",
+          cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "DmiDeniedPropagates.exclusive_addrtr.mapped_base_addr", cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "DmiNonOverlappingGrantReturnsFalse.exclusive_addrtr.target_socket.address",
+          cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "DmiNonOverlappingGrantReturnsFalse.exclusive_addrtr.target_socket.size",
+          cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "DmiNonOverlappingGrantReturnsFalse.exclusive_addrtr.mapped_base_addr",
+          cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "DmiGrantMustContainRequestedAddress.exclusive_addrtr.target_socket.address",
+          cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "DmiGrantMustContainRequestedAddress.exclusive_addrtr.target_socket.size",
+          cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "DmiGrantMustContainRequestedAddress.exclusive_addrtr.mapped_base_addr",
+          cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "InvalidateClippedStart.exclusive_addrtr.target_socket.address",
+          cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "InvalidateClippedStart.exclusive_addrtr.target_socket.size",
+          cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "InvalidateClippedStart.exclusive_addrtr.mapped_base_addr",
+          cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "InvalidateClippedEnd.exclusive_addrtr.target_socket.address",
+          cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "InvalidateClippedEnd.exclusive_addrtr.target_socket.size",
+          cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "InvalidateClippedEnd.exclusive_addrtr.mapped_base_addr", cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "InvalidateNonOverlappingLowIgnored.exclusive_addrtr.target_socket.address",
+          cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "InvalidateNonOverlappingLowIgnored.exclusive_addrtr.target_socket.size",
+          cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "InvalidateNonOverlappingLowIgnored.exclusive_addrtr.mapped_base_addr",
+          cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
+        { "InvalidateNonOverlappingHighIgnored.exclusive_addrtr.target_socket.address",
+          cci::cci_value(AddrtrTestBench::TARGET_BASE_ADDR) },
+        { "InvalidateNonOverlappingHighIgnored.exclusive_addrtr.target_socket.size",
+          cci::cci_value(AddrtrTestBench::TARGET_MMIO_SIZE) },
+        { "InvalidateNonOverlappingHighIgnored.exclusive_addrtr.mapped_base_addr",
+          cci::cci_value(AddrtrTestBench::MAPPED_BASE_ADDR) },
     });
 
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
- The dmi pointer was not mapped correctly before, so add the correct maping and preserve accurate DMI start/end addresses with the corresponding pointer offset when ranges are clipped.